### PR TITLE
Add time validation, team completion, and late check-in UX

### DIFF
--- a/src/app/actions/checkIn.ts
+++ b/src/app/actions/checkIn.ts
@@ -2,10 +2,13 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import { isAfterDeadline } from "@/lib/deadlineUtils";
 
 interface CheckInResult {
   success: boolean;
   error?: string;
+  isLate?: boolean;
+  dailyStatus?: "success" | "pending";
 }
 
 export async function recordCheckIn(
@@ -13,16 +16,29 @@ export async function recordCheckIn(
   goalId: string
 ): Promise<CheckInResult> {
   const supabase = await createClient();
-  const today = new Date().toISOString().split("T")[0];
-  const now = new Date().toISOString();
+  const now = new Date();
+  const today = now.toISOString().split("T")[0];
 
-  // Insert the check-in record — DB unique constraint on
-  // (profile_id, goal_id, date) prevents duplicates
+  // Fetch goal to check deadline_time and is_team
+  const { data: goal, error: goalError } = await supabase
+    .from("goals")
+    .select("deadline_time, is_team")
+    .eq("id", goalId)
+    .single();
+
+  if (goalError || !goal) {
+    return { success: false, error: "Failed to load goal" };
+  }
+
+  // Determine if this check-in is late
+  const isLate = isAfterDeadline(now, goal.deadline_time);
+
+  // Insert the check-in record — DB unique constraint prevents duplicates
   const { error: insertError } = await supabase.from("check_ins").insert({
     profile_id: profileId,
     goal_id: goalId,
     date: today,
-    checked_in_at: now,
+    checked_in_at: now.toISOString(),
   });
 
   if (insertError) {
@@ -32,7 +48,172 @@ export async function recordCheckIn(
     return { success: false, error: "Failed to record check-in" };
   }
 
-  revalidatePath("/");
+  // If late, just record it — don't evaluate success
+  if (isLate) {
+    revalidatePath("/");
+    return { success: true, isLate: true };
+  }
 
-  return { success: true };
+  // Evaluate team completion for on-time check-ins
+  const dailyStatus = await evaluateTeamCompletion(
+    supabase,
+    goalId,
+    goal.is_team,
+    goal.deadline_time,
+    today
+  );
+
+  revalidatePath("/");
+  return { success: true, isLate: false, dailyStatus };
+}
+
+/**
+ * After an on-time check-in, check if all team members have checked in
+ * on time. If so, mark the daily entry as "success".
+ */
+async function evaluateTeamCompletion(
+  supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>,
+  goalId: string,
+  isTeam: boolean,
+  deadlineTime: string | null,
+  today: string
+): Promise<"success" | "pending"> {
+  // Fetch participants and today's check-ins in parallel
+  const [{ data: participants }, { data: checkIns }] = await Promise.all([
+    supabase
+      .from("goal_participants")
+      .select("profile_id")
+      .eq("goal_id", goalId),
+    supabase
+      .from("check_ins")
+      .select("profile_id, checked_in_at")
+      .eq("goal_id", goalId)
+      .eq("date", today),
+  ]);
+
+  if (!participants || participants.length === 0 || !checkIns) return "pending";
+
+  // For team goals, all participants must have on-time check-ins
+  // For individual goals, just the current check-in being on-time is enough
+  const participantIds = new Set(participants.map((p) => p.profile_id));
+  const onTimeCheckIns = new Set(
+    checkIns
+      .filter((c) => {
+        if (!deadlineTime) return true; // untimed = always on time
+        return !isAfterDeadline(new Date(c.checked_in_at), deadlineTime);
+      })
+      .map((c) => c.profile_id)
+  );
+
+  const allCheckedIn = isTeam
+    ? [...participantIds].every((id) => onTimeCheckIns.has(id))
+    : onTimeCheckIns.size > 0;
+
+  if (!allCheckedIn) return "pending";
+
+  // All conditions met — mark today as success
+  await markDayAsSuccess(supabase, goalId, today);
+  return "success";
+}
+
+/**
+ * Create or update today's daily entry to "success" with sequential
+ * success_number and random decoration_seed.
+ */
+async function markDayAsSuccess(
+  supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>,
+  goalId: string,
+  date: string
+) {
+  // Count existing successes to determine next success_number
+  const { count } = await supabase
+    .from("daily_entries")
+    .select("*", { count: "exact", head: true })
+    .eq("goal_id", goalId)
+    .eq("status", "success");
+
+  const successNumber = (count ?? 0) + 1;
+  const decorationSeed = Math.floor(Math.random() * 10000);
+
+  // Upsert: create if doesn't exist, update if it does (e.g., was "pending")
+  await supabase
+    .from("daily_entries")
+    .upsert(
+      {
+        goal_id: goalId,
+        date,
+        status: "success" as const,
+        success_number: successNumber,
+        decoration_seed: decorationSeed,
+      },
+      { onConflict: "goal_id,date" }
+    );
+}
+
+/**
+ * Ensure today's daily entry exists as "pending" (if today is an active day).
+ * Transition any past pending entries to "miss" if their deadline has passed.
+ * Called from page.tsx on dashboard load.
+ */
+export async function ensureDailyEntries(goalId: string) {
+  const supabase = await createClient();
+  const now = new Date();
+  const today = now.toISOString().split("T")[0];
+  const dayOfWeek = now.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+
+  // Fetch goal config
+  const { data: goal } = await supabase
+    .from("goals")
+    .select("active_days, deadline_time, start_date")
+    .eq("id", goalId)
+    .single();
+
+  if (!goal) return;
+
+  const activeDays = (goal.active_days as number[]) ?? [];
+
+  // Create today's entry if it's an active day and doesn't exist yet
+  if (activeDays.includes(dayOfWeek) && today >= goal.start_date) {
+    const { data: todayEntry } = await supabase
+      .from("daily_entries")
+      .select("id")
+      .eq("goal_id", goalId)
+      .eq("date", today)
+      .maybeSingle();
+
+    if (!todayEntry) {
+      await supabase.from("daily_entries").insert({
+        goal_id: goalId,
+        date: today,
+        status: "pending" as const,
+      });
+    }
+  }
+
+  // Transition past pending entries to "miss" if deadline has passed
+  if (goal.deadline_time) {
+    const { data: pendingEntries } = await supabase
+      .from("daily_entries")
+      .select("id, date")
+      .eq("goal_id", goalId)
+      .eq("status", "pending")
+      .lte("date", today);
+
+    if (pendingEntries) {
+      // Past days are always missed; today is missed only if deadline has passed
+      const missedIds = pendingEntries
+        .filter((entry) => {
+          if (entry.date < today) return true;
+          return entry.date === today && isAfterDeadline(now, goal.deadline_time);
+        })
+        .map((entry) => entry.id);
+
+      if (missedIds.length > 0) {
+        await supabase
+          .from("daily_entries")
+          .update({ status: "miss" as const })
+          .in("id", missedIds);
+      }
+    }
+  }
 }

--- a/src/app/components/CheckInModal.tsx
+++ b/src/app/components/CheckInModal.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import type { ParticipantProfile } from "@/types/database";
 import { recordCheckIn } from "@/app/actions/checkIn";
 import { getAvatarIcon } from "@/lib/avatarUtils";
+import { getRandomLateMessage } from "@/lib/lateMessages";
 
 const CHECKLIST_ITEMS = [
-  { label: "Teeth", emoji: "🪥", bg: "#E8F5E9" },
-  { label: "Clothes", emoji: "👕", bg: "#FFF3E0" },
-  { label: "Potty", emoji: "🚽", bg: "#E8F5E9" },
-  { label: "Breakfast", emoji: "🍴", bg: "#FCE4EC" },
-  { label: "Shoes", emoji: "👟", bg: "#FCE4EC" },
+  { label: "Teeth", emoji: "\u{1FAA5}", bg: "#E8F5E9" },
+  { label: "Clothes", emoji: "\u{1F455}", bg: "#FFF3E0" },
+  { label: "Potty", emoji: "\u{1F6BD}", bg: "#E8F5E9" },
+  { label: "Breakfast", emoji: "\u{1F374}", bg: "#FCE4EC" },
+  { label: "Shoes", emoji: "\u{1F45F}", bg: "#FCE4EC" },
 ];
 
 interface CheckInModalProps {
@@ -18,6 +19,9 @@ interface CheckInModalProps {
   goalId: string;
   participants: { profiles: ParticipantProfile }[];
   checkedInProfileIds: string[];
+  isLate: boolean;
+  isTeam: boolean;
+  isTimed: boolean;
   onClose: () => void;
   onCheckInComplete: (profileId: string) => void;
 }
@@ -27,11 +31,19 @@ export default function CheckInModal({
   goalId,
   participants,
   checkedInProfileIds,
+  isLate,
+  isTeam,
+  isTimed,
   onClose,
   onCheckInComplete,
 }: CheckInModalProps) {
   const [isPending, startTransition] = useTransition();
   const alreadyCheckedIn = checkedInProfileIds.includes(profile.id);
+
+  // Pick a random late message once when the modal mounts
+  const [lateMessage] = useState(() =>
+    isLate ? getRandomLateMessage(isTimed, isTeam) : null
+  );
 
   // Close on Escape key
   useEffect(() => {
@@ -87,81 +99,110 @@ export default function CheckInModal({
             {getAvatarIcon(profile.avatar)}
           </div>
           <h2 className="text-2xl font-extrabold text-gray-800">{profile.name}</h2>
-          <p className="text-gray-500 mt-1">Have you done everything?</p>
         </div>
 
-        {/* Checklist — view-only icons */}
-        <div className="flex justify-center gap-3 mb-6">
-          {CHECKLIST_ITEMS.map((item) => (
-            <div key={item.label} className="flex flex-col items-center gap-1">
-              <div
-                className="w-14 h-14 rounded-xl flex items-center justify-center text-2xl"
-                style={{ backgroundColor: item.bg }}
-              >
-                {item.emoji}
-              </div>
-              <span className="text-xs text-gray-500 font-semibold">{item.label}</span>
+        {isLate && lateMessage && !alreadyCheckedIn ? (
+          /* ── Late check-in state ── */
+          <>
+            <div className="text-center mb-6">
+              <p className="text-lg font-bold text-gray-700 mb-2">
+                {lateMessage.heading}
+              </p>
+              <p className="text-gray-500">{lateMessage.body}</p>
             </div>
-          ))}
-        </div>
 
-        {/* Team status bar */}
-        <div className="flex flex-col gap-2 mb-6">
-          {participants.map((p) => {
-            const member = p.profiles;
-            if (!member) return null;
-            const isCurrentKid = member.id === profile.id;
-            const hasCheckedIn = checkedInProfileIds.includes(member.id);
-            return (
-              <div key={member.id} className="flex items-center gap-2">
-                <div
-                  className="w-7 h-7 rounded-full flex items-center justify-center text-sm"
-                  style={{
-                    backgroundColor: isCurrentKid || hasCheckedIn
-                      ? (member.color ?? "#ccc")
-                      : "#e5e7eb",
-                  }}
-                >
-                  {getAvatarIcon(member.avatar)}
-                </div>
-                {isCurrentKid ? (
-                  <span
-                    className="text-sm font-bold px-3 py-1 rounded-full text-white"
-                    style={{ backgroundColor: member.color ?? "#ccc" }}
+            <button
+              onClick={handleCheckIn}
+              disabled={isPending}
+              className="w-full py-4 rounded-2xl text-white font-extrabold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: "#f59e0b",
+                fontSize: "18px",
+                minHeight: "56px",
+              }}
+            >
+              {isPending ? "Recording..." : lateMessage.button}
+            </button>
+          </>
+        ) : (
+          /* ── Normal check-in state ── */
+          <>
+            <p className="text-gray-500 text-center mb-4">Have you done everything?</p>
+
+            {/* Checklist — view-only icons */}
+            <div className="flex justify-center gap-3 mb-6">
+              {CHECKLIST_ITEMS.map((item) => (
+                <div key={item.label} className="flex flex-col items-center gap-1">
+                  <div
+                    className="w-14 h-14 rounded-xl flex items-center justify-center text-2xl"
+                    style={{ backgroundColor: item.bg }}
                   >
-                    {member.name}: checking in now
-                  </span>
-                ) : hasCheckedIn ? (
-                  <span className="text-sm font-bold text-gray-700">
-                    {member.name}: checked in ✓
-                  </span>
-                ) : (
-                  <span className="text-sm text-gray-400">
-                    {member.name}: not yet checked in
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                    {item.emoji}
+                  </div>
+                  <span className="text-xs text-gray-500 font-semibold">{item.label}</span>
+                </div>
+              ))}
+            </div>
 
-        {/* "I'm Ready!" button — 18px+ text per PRD, 44px+ touch target */}
-        <button
-          onClick={handleCheckIn}
-          disabled={alreadyCheckedIn || isPending}
-          className="w-full py-4 rounded-2xl text-white font-extrabold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{
-            backgroundColor: alreadyCheckedIn ? "#9ca3af" : "var(--color-primary)",
-            fontSize: "18px",
-            minHeight: "56px",
-          }}
-        >
-          {isPending
-            ? "Checking in..."
-            : alreadyCheckedIn
-              ? "Already checked in ✓"
-              : "I'm Ready!"}
-        </button>
+            {/* Team status bar */}
+            <div className="flex flex-col gap-2 mb-6">
+              {participants.map((p) => {
+                const member = p.profiles;
+                if (!member) return null;
+                const isCurrentKid = member.id === profile.id;
+                const hasCheckedIn = checkedInProfileIds.includes(member.id);
+                return (
+                  <div key={member.id} className="flex items-center gap-2">
+                    <div
+                      className="w-7 h-7 rounded-full flex items-center justify-center text-sm"
+                      style={{
+                        backgroundColor: isCurrentKid || hasCheckedIn
+                          ? (member.color ?? "#ccc")
+                          : "#e5e7eb",
+                      }}
+                    >
+                      {getAvatarIcon(member.avatar)}
+                    </div>
+                    {isCurrentKid ? (
+                      <span
+                        className="text-sm font-bold px-3 py-1 rounded-full text-white"
+                        style={{ backgroundColor: member.color ?? "#ccc" }}
+                      >
+                        {member.name}: checking in now
+                      </span>
+                    ) : hasCheckedIn ? (
+                      <span className="text-sm font-bold text-gray-700">
+                        {member.name}: checked in &#10003;
+                      </span>
+                    ) : (
+                      <span className="text-sm text-gray-400">
+                        {member.name}: not yet checked in
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* "I'm Ready!" button — 18px+ text per PRD, 44px+ touch target */}
+            <button
+              onClick={handleCheckIn}
+              disabled={alreadyCheckedIn || isPending}
+              className="w-full py-4 rounded-2xl text-white font-extrabold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: alreadyCheckedIn ? "#9ca3af" : "var(--color-primary)",
+                fontSize: "18px",
+                minHeight: "56px",
+              }}
+            >
+              {isPending
+                ? "Checking in..."
+                : alreadyCheckedIn
+                  ? "Already checked in \u2713"
+                  : "I'm Ready!"}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/app/components/ParticipantAvatars.tsx
+++ b/src/app/components/ParticipantAvatars.tsx
@@ -9,12 +9,18 @@ interface ParticipantAvatarsProps {
   participants: { profiles: ParticipantProfile }[];
   goalId: string;
   initialCheckedInProfileIds: string[];
+  isLate: boolean;
+  isTeam: boolean;
+  isTimed: boolean;
 }
 
 export default function ParticipantAvatars({
   participants,
   goalId,
   initialCheckedInProfileIds,
+  isLate,
+  isTeam,
+  isTimed,
 }: ParticipantAvatarsProps) {
   const [openProfileId, setOpenProfileId] = useState<string | null>(null);
   const [checkedInProfileIds, setCheckedInProfileIds] = useState<string[]>(
@@ -81,6 +87,9 @@ export default function ParticipantAvatars({
           goalId={goalId}
           participants={participants}
           checkedInProfileIds={checkedInProfileIds}
+          isLate={isLate}
+          isTeam={isTeam}
+          isTimed={isTimed}
           onClose={handleCloseModal}
           onCheckInComplete={handleCheckInComplete}
         />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,8 @@ import CalendarGrid from "@/app/components/CalendarGrid";
 import LiveClock from "@/app/components/LiveClock";
 import MarbleJar from "@/app/components/MarbleJar";
 import ParticipantAvatars from "@/app/components/ParticipantAvatars";
+import { ensureDailyEntries } from "@/app/actions/checkIn";
+import { isAfterDeadline } from "@/lib/deadlineUtils";
 
 type Goal = Database["public"]["Tables"]["goals"]["Row"];
 type DailyEntry = Database["public"]["Tables"]["daily_entries"]["Row"];
@@ -29,9 +31,17 @@ export default async function DashboardPage() {
   let participants: { profiles: ParticipantProfile }[] = [];
   let entries: DailyEntry[] = [];
   let checkedInProfileIds: string[] = [];
+  let isLate = false;
 
   if (goal) {
-    const today = new Date().toISOString().split("T")[0];
+    // Ensure today's daily entry exists and transition past pending → miss
+    await ensureDailyEntries(goal.id);
+
+    const now = new Date();
+    const today = now.toISOString().split("T")[0];
+
+    // Determine if we're past the deadline
+    isLate = isAfterDeadline(now, goal.deadline_time);
 
     const [
       { data: participantData, error: partError },
@@ -112,6 +122,9 @@ export default async function DashboardPage() {
             participants={participants}
             goalId={goal.id}
             initialCheckedInProfileIds={checkedInProfileIds}
+            isLate={isLate}
+            isTeam={goal.is_team}
+            isTimed={!!goal.deadline_time}
           />
         </aside>
       </div>

--- a/src/lib/deadlineUtils.ts
+++ b/src/lib/deadlineUtils.ts
@@ -1,0 +1,16 @@
+/**
+ * Check if the current time is past the goal's deadline.
+ * Returns false if no deadline is set (untimed goals).
+ */
+export function isAfterDeadline(
+  now: Date,
+  deadlineTime: string | null
+): boolean {
+  if (!deadlineTime) return false;
+
+  const [hours, minutes, seconds] = deadlineTime.split(":").map(Number);
+  const deadline = new Date(now);
+  deadline.setHours(hours, minutes, seconds ?? 0, 0);
+
+  return now > deadline;
+}

--- a/src/lib/lateMessages.ts
+++ b/src/lib/lateMessages.ts
@@ -1,0 +1,131 @@
+interface LateMessage {
+  heading: string;
+  body: string;
+  button: string;
+}
+
+const TIMED_INDIVIDUAL: LateMessage[] = [
+  {
+    heading: "Oops, you were a little late today!",
+    body: "Think about what you can do to be ready earlier next time.",
+    button: "I can do it next time!",
+  },
+  {
+    heading: "Oh no, the time ran out!",
+    body: "You didn't make it today, but that's OK \u2014 you can do it next time!",
+    button: "I'll get it next time!",
+  },
+  {
+    heading: "Almost! You were so close today.",
+    body: "What's one thing you could do faster next time?",
+    button: "I've got a plan!",
+  },
+  {
+    heading: "Not quite on time today.",
+    body: "That's OK \u2014 every day is a chance to try again. You've got this!",
+    button: "I'll be ready next time!",
+  },
+  {
+    heading: "The clock beat you today!",
+    body: "But you're getting better. Think about one thing that slowed you down.",
+    button: "I know what to do next time!",
+  },
+];
+
+const TIMED_TEAM: LateMessage[] = [
+  {
+    heading: "Your team was a little late today!",
+    body: "Think about how you can help each other be ready faster next time.",
+    button: "We'll do better next time!",
+  },
+  {
+    heading: "Oh no, the time ran out for your team!",
+    body: "You didn't make it today, but you can work together to get it next time!",
+    button: "We'll get it next time!",
+  },
+  {
+    heading: "Almost! Your team was so close today.",
+    body: "How can you help each other be even faster next time?",
+    button: "We've got a plan!",
+  },
+  {
+    heading: "Your team didn't quite make it today.",
+    body: "That's OK \u2014 you're a team and you can figure this out together!",
+    button: "We'll be ready next time!",
+  },
+  {
+    heading: "The clock beat your team today!",
+    body: "Talk to each other about what slowed you down. You'll crack it!",
+    button: "We know what to do next time!",
+  },
+];
+
+const UNTIMED_INDIVIDUAL: LateMessage[] = [
+  {
+    heading: "You didn't get this one done today.",
+    body: "That's OK! Think about what you can do differently next time.",
+    button: "I'll try next time!",
+  },
+  {
+    heading: "This one didn't happen today.",
+    body: "No worries \u2014 next time is a fresh start!",
+    button: "I've got this!",
+  },
+  {
+    heading: "Not today, but that's alright!",
+    body: "Think about what got in the way and how to make it easier next time.",
+    button: "I'll figure it out!",
+  },
+  {
+    heading: "You missed this one today.",
+    body: "Everyone has days like this. What matters is trying again!",
+    button: "I'm not giving up!",
+  },
+  {
+    heading: "Today didn't go as planned.",
+    body: "That happens sometimes! You can get back on track next time.",
+    button: "I'll bounce back!",
+  },
+];
+
+const UNTIMED_TEAM: LateMessage[] = [
+  {
+    heading: "Your team didn't get this one done today.",
+    body: "That's OK! Talk about how you can help each other next time.",
+    button: "We'll try next time!",
+  },
+  {
+    heading: "This one didn't happen for your team today.",
+    body: "No worries \u2014 next time is a fresh start for everyone!",
+    button: "We've got this!",
+  },
+  {
+    heading: "Not today, but that's alright!",
+    body: "Think about what got in the way and how your team can help each other next time.",
+    button: "We'll figure it out!",
+  },
+  {
+    heading: "Your team missed this one today.",
+    body: "Every team has days like this. What matters is trying again together!",
+    button: "We're not giving up!",
+  },
+  {
+    heading: "Today didn't go as planned for your team.",
+    body: "That happens sometimes! You can get back on track together next time.",
+    button: "We'll bounce back!",
+  },
+];
+
+export function getRandomLateMessage(
+  isTimed: boolean,
+  isTeam: boolean
+): LateMessage {
+  const pool = isTimed
+    ? isTeam
+      ? TIMED_TEAM
+      : TIMED_INDIVIDUAL
+    : isTeam
+      ? UNTIMED_TEAM
+      : UNTIMED_INDIVIDUAL;
+  return pool[Math.floor(Math.random() * pool.length)];
+}


### PR DESCRIPTION
## Summary
- **Deadline enforcement**: check-ins compared against goal's `deadline_time` — late check-ins are recorded but don't count toward success
- **Team completion**: for team goals, all participants must check in on time before the day is marked as success; individual goals succeed on any on-time check-in
- **Daily entry lifecycle**: `ensureDailyEntries()` auto-creates today's pending entry on page load and bulk-transitions past pending entries to "miss"
- **Late check-in UX**: 20 encouraging messages across 4 categories (timed/untimed × team/individual), randomly selected per modal open
- **Efficiency improvements from `/simplify`**: parallelized DB queries, bulk updates (N+1 → single query), atomic upserts, extracted shared `isAfterDeadline` utility

## Test plan
- [ ] Check in before deadline — should see "I'm Ready!" flow, marble added to jar
- [ ] Check in after deadline — should see random encouraging message with amber button
- [ ] Verify late check-in records but doesn't add marble
- [ ] Team goal: verify marble only appears when ALL kids check in on time
- [ ] Reload page after deadline — pending entries should transition to "miss"
- [ ] Check that different late messages appear on repeated visits

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)