### PR TITLE
Add kid profile management and unify checklist icons

### DIFF
--- a/src/app/actions/kids.ts
+++ b/src/app/actions/kids.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+export async function createKid(formData: FormData) {
+  const supabase = await createClient();
+
+  const { data: family } = await supabase
+    .from("families")
+    .select("id")
+    .limit(1)
+    .single();
+  if (!family) throw new Error("No family found");
+
+  const name = (formData.get("name") as string)?.trim();
+  const avatar = formData.get("avatar") as string;
+  const color = formData.get("color") as string;
+
+  if (!name) throw new Error("Name is required");
+  if (!avatar) throw new Error("Avatar is required");
+
+  const { error } = await supabase.from("profiles").insert({
+    family_id: family.id,
+    name,
+    avatar,
+    role: "child" as const,
+    color: color || null,
+  });
+
+  if (error) throw new Error(`Failed to create profile: ${error.message}`);
+
+  revalidatePath("/admin/kids");
+  revalidatePath("/");
+}
+
+export async function updateKid(profileId: string, formData: FormData) {
+  const supabase = await createClient();
+
+  const name = (formData.get("name") as string)?.trim();
+  const avatar = formData.get("avatar") as string;
+  const color = formData.get("color") as string;
+
+  if (!name) throw new Error("Name is required");
+  if (!avatar) throw new Error("Avatar is required");
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ name, avatar, color: color || null })
+    .eq("id", profileId);
+
+  if (error) throw new Error(`Failed to update profile: ${error.message}`);
+
+  revalidatePath("/admin/kids");
+  revalidatePath("/");
+}
+
+export async function deleteKid(profileId: string) {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("profiles")
+    .delete()
+    .eq("id", profileId);
+
+  if (error) throw new Error(`Failed to delete profile: ${error.message}`);
+
+  revalidatePath("/admin/kids");
+  revalidatePath("/");
+}

--- a/src/app/admin/components/GoalForm.tsx
+++ b/src/app/admin/components/GoalForm.tsx
@@ -2,48 +2,29 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { X, Plus, Trash2 } from "lucide-react";
-import * as LucideIcons from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import type { Database } from "@/types/database";
-
-const lucideIconMap = LucideIcons as unknown as Record<string, LucideIcon>;
 
 type Goal = Database["public"]["Tables"]["goals"]["Row"];
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
 
-// Curated icon set for checklist items (kid-friendly activities)
-const CHECKLIST_ICONS = [
-  "Brush",
-  "Shirt",
-  "Utensils",
-  "Footprints",
-  "Bath",
-  "BookOpen",
-  "Backpack",
-  "Bed",
-  "Moon",
-  "Sun",
-  "Music",
-  "Apple",
-  "Heart",
-  "Star",
-  "Smile",
-  "HandHeart",
-  "Dog",
-  "Cat",
-  "Baby",
-  "Bike",
-  "TreePine",
-  "Flower2",
-  "Pencil",
-  "Palette",
-  "Dumbbell",
-  "GlassWater",
-] as const;
+// Curated emoji set for checklist items (kid-friendly activities)
+const CHECKLIST_EMOJIS = [
+  "🪥", "👕", "🍴", "👟", "🚽", "🧼", "📚", "🎒",
+  "🛏️", "🌙", "☀️", "🎵", "🍎", "❤️", "⭐", "😊",
+  "🐕", "🐈", "🚲", "🌲", "✏️", "🎨", "💪", "🥤",
+  "🧹", "💊", "👓", "⏰", "🔑", "✅", "🥪", "🥛",
+];
+
+// Common prize/reward emojis for the emoji picker
+const PRIZE_EMOJIS = [
+  "🍨", "🍦", "🎂", "🍕", "🍩", "🧁", "🍿", "🎬",
+  "🎮", "🎯", "🎪", "🎢", "🏊", "⚽", "🎁", "🧸",
+  "🦄", "🌈", "⭐", "🏆", "👑", "🎉", "🎈", "💎",
+];
 
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-type ChecklistItem = { icon: string; label: string };
+type ChecklistItem = { emoji: string; label: string };
 
 interface GoalFormProps {
   goal?: Goal & { participants?: string[] };
@@ -64,9 +45,20 @@ export default function GoalForm({
 
   const [name, setName] = useState(goal?.name || "");
   const [description, setDescription] = useState(goal?.description || "");
-  const [checklistItems, setChecklistItems] = useState<ChecklistItem[]>(
-    (goal?.checklist_items as ChecklistItem[]) || []
-  );
+  const [checklistItems, setChecklistItems] = useState<ChecklistItem[]>(() => {
+    const raw = goal?.checklist_items;
+    if (!raw || !Array.isArray(raw)) return [];
+    // Handle all legacy formats:
+    // - string[] from seed data → { emoji: "⭐", label: string }
+    // - { icon, label } from old Lucide form → { emoji: "⭐", label }
+    // - { emoji, label } from new form → use as-is
+    return (raw as (string | Record<string, string>)[]).map((item) => {
+      if (typeof item === "string") return { emoji: "⭐", label: item };
+      if ("emoji" in item) return { emoji: item.emoji, label: item.label };
+      if ("icon" in item) return { emoji: "⭐", label: item.label || "" };
+      return { emoji: "⭐", label: "" };
+    });
+  });
   const [targetCount, setTargetCount] = useState(
     mode === "restart" ? 20 : goal?.target_count || 20
   );
@@ -106,8 +98,8 @@ export default function GoalForm({
     return groups;
   }, []);
 
-  // Icon picker state
-  const [iconPickerIndex, setIconPickerIndex] = useState<number | null>(null);
+  // Emoji picker state for checklist items
+  const [emojiPickerIndex, setEmojiPickerIndex] = useState<number | null>(null);
 
   function toggleDay(day: number) {
     setActiveDays((prev) =>
@@ -122,14 +114,14 @@ export default function GoalForm({
   }
 
   function addChecklistItem() {
-    setChecklistItems((prev) => [...prev, { icon: "Star", label: "" }]);
+    setChecklistItems((prev) => [...prev, { emoji: "⭐", label: "" }]);
   }
 
   function removeChecklistItem(index: number) {
     setChecklistItems((prev) => prev.filter((_, i) => i !== index));
-    if (iconPickerIndex === null) return;
-    if (iconPickerIndex === index) setIconPickerIndex(null);
-    else if (iconPickerIndex > index) setIconPickerIndex(iconPickerIndex - 1);
+    if (emojiPickerIndex === null) return;
+    if (emojiPickerIndex === index) setEmojiPickerIndex(null);
+    else if (emojiPickerIndex > index) setEmojiPickerIndex(emojiPickerIndex - 1);
   }
 
   function updateChecklistItem(
@@ -227,74 +219,65 @@ export default function GoalForm({
         {mode !== "restart" && (
           <FieldGroup label="Checklist Items">
             <div className="flex flex-col gap-2">
-              {checklistItems.map((item, i) => {
-                const IconComponent =
-                  lucideIconMap[
-                    item.icon
-                  ] || LucideIcons.Star;
-                return (
-                  <div key={i} className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setIconPickerIndex(iconPickerIndex === i ? null : i)
-                      }
-                      className="shrink-0 w-10 h-10 flex items-center justify-center border border-gray-200"
-                      style={{ borderRadius: "var(--radius-card)" }}
-                    >
-                      <IconComponent size={20} />
-                    </button>
-                    <input
-                      type="text"
-                      value={item.label}
-                      onChange={(e) =>
-                        updateChecklistItem(i, "label", e.target.value)
-                      }
-                      placeholder="e.g., Brush teeth"
-                      className="flex-1 border border-gray-200 px-3 py-2 text-sm"
-                      style={{ borderRadius: "var(--radius-card)" }}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removeChecklistItem(i)}
-                      className="shrink-0 p-2 text-text-secondary"
-                      style={{ minHeight: 44, minWidth: 44 }}
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  </div>
-                );
-              })}
+              {checklistItems.map((item, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setEmojiPickerIndex(emojiPickerIndex === i ? null : i)
+                    }
+                    className="shrink-0 w-10 h-10 flex items-center justify-center border border-gray-200 text-xl"
+                    style={{ borderRadius: "var(--radius-card)" }}
+                  >
+                    {item.emoji}
+                  </button>
+                  <input
+                    type="text"
+                    value={item.label}
+                    onChange={(e) =>
+                      updateChecklistItem(i, "label", e.target.value)
+                    }
+                    placeholder="e.g., Brush teeth"
+                    className="flex-1 border border-gray-200 px-3 py-2 text-sm"
+                    style={{ borderRadius: "var(--radius-card)" }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeChecklistItem(i)}
+                    className="shrink-0 p-2 text-text-secondary"
+                    style={{ minHeight: 44, minWidth: 44 }}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              ))}
 
-              {/* Inline icon picker */}
-              {iconPickerIndex !== null && (
+              {/* Inline emoji picker for checklist items */}
+              {emojiPickerIndex !== null && (
                 <div
                   className="grid grid-cols-8 gap-1 p-2 border border-gray-200 bg-gray-50"
                   style={{ borderRadius: "var(--radius-card)" }}
                 >
-                  {CHECKLIST_ICONS.map((iconName) => {
-                    const Ic = lucideIconMap[iconName];
-                    if (!Ic) return null;
+                  {CHECKLIST_EMOJIS.map((emoji) => {
                     const selected =
-                      checklistItems[iconPickerIndex]?.icon === iconName;
+                      checklistItems[emojiPickerIndex]?.emoji === emoji;
                     return (
                       <button
-                        key={iconName}
+                        key={emoji}
                         type="button"
                         onClick={() => {
-                          updateChecklistItem(iconPickerIndex, "icon", iconName);
-                          setIconPickerIndex(null);
+                          updateChecklistItem(emojiPickerIndex, "emoji", emoji);
+                          setEmojiPickerIndex(null);
                         }}
-                        className="w-8 h-8 flex items-center justify-center"
+                        className="w-9 h-9 flex items-center justify-center text-xl"
                         style={{
                           borderRadius: 4,
                           backgroundColor: selected
                             ? "var(--color-primary-light)"
                             : "transparent",
                         }}
-                        title={iconName}
                       >
-                        <Ic size={16} />
+                        {emoji}
                       </button>
                     );
                   })}
@@ -330,14 +313,10 @@ export default function GoalForm({
             />
           </FieldGroup>
           <FieldGroup label="Prize Emoji">
-            <input
-              type="text"
+            <EmojiPicker
               value={prizeEmoji}
-              onChange={(e) => setPrizeEmoji(e.target.value)}
-              placeholder="🍦"
-              maxLength={4}
-              className="w-full border border-gray-200 px-3 py-2 text-base"
-              style={{ borderRadius: "var(--radius-card)" }}
+              onChange={setPrizeEmoji}
+              options={PRIZE_EMOJIS}
             />
           </FieldGroup>
         </div>
@@ -521,6 +500,57 @@ export default function GoalForm({
           </button>
         </div>
       </form>
+    </div>
+  );
+}
+
+function EmojiPicker({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (emoji: string) => void;
+  options: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full border border-gray-200 px-3 py-2 text-base text-left flex items-center gap-2"
+        style={{ borderRadius: "var(--radius-card)", minHeight: 42 }}
+      >
+        {value ? (
+          <span className="text-xl">{value}</span>
+        ) : (
+          <span className="text-gray-400">Choose emoji...</span>
+        )}
+      </button>
+      {open && (
+        <div
+          className="absolute z-10 top-full left-0 mt-1 p-2 bg-white border border-gray-200 shadow-lg grid grid-cols-8 gap-1"
+          style={{ borderRadius: "var(--radius-card)", width: "max-content" }}
+        >
+          {options.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => {
+                onChange(emoji);
+                setOpen(false);
+              }}
+              className="w-9 h-9 flex items-center justify-center text-xl rounded-lg hover:bg-gray-100"
+              style={{
+                backgroundColor: value === emoji ? "var(--color-primary-light)" : undefined,
+              }}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/admin/components/KidCard.tsx
+++ b/src/app/admin/components/KidCard.tsx
@@ -1,0 +1,51 @@
+import { getAvatarIcon, getAvatarLabel } from "@/lib/avatarUtils";
+import type { Database } from "@/types/database";
+
+type Profile = Database["public"]["Tables"]["profiles"]["Row"];
+
+export default function KidCard({
+  profile,
+  onEdit,
+}: {
+  profile: Profile;
+  onEdit: () => void;
+}) {
+  return (
+    <div
+      className="bg-surface p-4 flex items-center gap-4"
+      style={{ borderRadius: "var(--radius-card)" }}
+    >
+      {/* Avatar */}
+      <div
+        className="w-12 h-12 rounded-full flex items-center justify-center text-2xl shrink-0"
+        style={{ backgroundColor: profile.color ?? "#ccc" }}
+      >
+        {getAvatarIcon(profile.avatar)}
+      </div>
+
+      {/* Name + avatar label */}
+      <div className="flex-1 min-w-0">
+        <h3 className="font-bold text-base truncate">{profile.name}</h3>
+        <p className="text-sm text-text-secondary">
+          Avatar: {getAvatarLabel(profile.avatar)}
+        </p>
+      </div>
+
+      {/* Edit button */}
+      <button
+        onClick={onEdit}
+        className="text-sm font-semibold shrink-0"
+        style={{
+          color: "var(--color-primary)",
+          minWidth: 44,
+          minHeight: 44,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        Edit
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/components/KidForm.tsx
+++ b/src/app/admin/components/KidForm.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import {
+  AVATAR_OPTIONS,
+  COLOR_PALETTE,
+  getAvatarIcon,
+} from "@/lib/avatarUtils";
+import type { Database } from "@/types/database";
+
+type Profile = Database["public"]["Tables"]["profiles"]["Row"];
+
+interface KidFormProps {
+  mode: "create" | "edit";
+  profile?: Profile;
+  onSubmit: (formData: FormData) => Promise<void>;
+  onCancel: () => void;
+  onDelete?: () => Promise<void>;
+}
+
+export default function KidForm({
+  mode,
+  profile,
+  onSubmit,
+  onCancel,
+  onDelete,
+}: KidFormProps) {
+  const [name, setName] = useState(profile?.name ?? "");
+  const [avatar, setAvatar] = useState(
+    profile?.avatar ?? ""
+  );
+  const [color, setColor] = useState(
+    profile?.color ?? COLOR_PALETTE[0].hex
+  );
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (!avatar) {
+      setError("Please choose an avatar");
+      return;
+    }
+
+    const fd = new FormData();
+    fd.set("name", name.trim());
+    fd.set("avatar", avatar);
+    fd.set("color", color);
+
+    startTransition(async () => {
+      try {
+        await onSubmit(fd);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!onDelete) return;
+    startTransition(async () => {
+      try {
+        await onDelete();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete");
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-backdrop-in"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white rounded-3xl p-6 w-full max-w-md relative animate-modal-in overflow-y-auto"
+        style={{
+          boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+          maxHeight: "90vh",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          onClick={onCancel}
+          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          aria-label="Close"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+
+        <h2 className="text-xl font-bold mb-5">
+          {mode === "create" ? "Add Child" : "Edit Child"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter child's name"
+              className="w-full px-4 py-3 border border-gray-300 rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              autoFocus
+            />
+          </div>
+
+          {/* Avatar picker */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              Avatar
+            </label>
+            <div className="grid grid-cols-4 gap-3">
+              {AVATAR_OPTIONS.map((opt) => {
+                const selected = avatar === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    onClick={() => setAvatar(opt.id)}
+                    className="flex flex-col items-center gap-1 p-2 rounded-xl transition-colors"
+                    style={{
+                      backgroundColor: selected
+                        ? "var(--color-primary-light)"
+                        : "#F7F5F3",
+                      border: selected
+                        ? "2px solid var(--color-primary)"
+                        : "2px solid transparent",
+                      minHeight: 44,
+                    }}
+                  >
+                    <span className="text-2xl">{opt.emoji}</span>
+                    <span
+                      className="text-xs font-semibold"
+                      style={{
+                        color: selected
+                          ? "var(--color-primary)"
+                          : "var(--color-text-secondary)",
+                      }}
+                    >
+                      {opt.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Color picker */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              Color
+            </label>
+            <div className="flex flex-wrap gap-3">
+              {COLOR_PALETTE.map((c) => {
+                const selected = color === c.hex;
+                return (
+                  <button
+                    key={c.hex}
+                    type="button"
+                    onClick={() => setColor(c.hex)}
+                    className="w-9 h-9 rounded-full flex items-center justify-center transition-transform"
+                    style={{
+                      backgroundColor: c.hex,
+                      border: selected
+                        ? "3px solid var(--color-text-primary)"
+                        : "3px solid transparent",
+                      transform: selected ? "scale(1.15)" : "scale(1)",
+                    }}
+                    aria-label={c.label}
+                    title={c.label}
+                  >
+                    {selected && (
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Preview */}
+          {avatar && (
+            <div className="flex items-center gap-3 p-3 rounded-xl" style={{ backgroundColor: "#F7F5F3" }}>
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center text-xl"
+                style={{ backgroundColor: color }}
+              >
+                {getAvatarIcon(avatar)}
+              </div>
+              <span className="font-semibold text-gray-700">
+                {name.trim() || "Preview"}
+              </span>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <p className="text-sm text-red-600 font-semibold">{error}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="flex-1 py-3 text-white font-bold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: "var(--color-primary)",
+                minHeight: 48,
+              }}
+            >
+              {isPending
+                ? "Saving..."
+                : mode === "create"
+                  ? "Add Child"
+                  : "Save Changes"}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isPending}
+              className="px-5 py-3 font-semibold rounded-xl text-gray-600"
+              style={{
+                backgroundColor: "#F5F5F5",
+                minHeight: 48,
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+
+          {/* Delete — edit mode only */}
+          {mode === "edit" && onDelete && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isPending}
+              className="w-full py-2 text-sm font-semibold text-red-500 hover:text-red-700 transition-colors disabled:opacity-50"
+            >
+              Delete this child
+            </button>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/components/KidsContent.tsx
+++ b/src/app/admin/components/KidsContent.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import KidCard from "./KidCard";
+import KidForm from "./KidForm";
+import { createKid, updateKid, deleteKid } from "@/app/actions/kids";
+import type { Database } from "@/types/database";
+
+type Profile = Database["public"]["Tables"]["profiles"]["Row"];
+
+type FormMode =
+  | { kind: "closed" }
+  | { kind: "create" }
+  | { kind: "edit"; profile: Profile };
+
+export default function KidsContent({
+  kids,
+}: {
+  kids: Profile[];
+}) {
+  const [formMode, setFormMode] = useState<FormMode>({ kind: "closed" });
+
+  async function handleCreate(fd: FormData) {
+    await createKid(fd);
+    setFormMode({ kind: "closed" });
+  }
+
+  async function handleEdit(profileId: string, fd: FormData) {
+    await updateKid(profileId, fd);
+    setFormMode({ kind: "closed" });
+  }
+
+  async function handleDelete(profileId: string) {
+    await deleteKid(profileId);
+    setFormMode({ kind: "closed" });
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-bold">Manage Kids</h2>
+        <button
+          onClick={() => setFormMode({ kind: "create" })}
+          className="flex items-center gap-2 bg-primary text-text-on-primary px-4 py-2 font-semibold"
+          style={{ borderRadius: "var(--radius-button)", minHeight: 44 }}
+        >
+          <Plus size={18} />
+          Add Child
+        </button>
+      </div>
+
+      {kids.length === 0 ? (
+        <p className="text-text-secondary py-8 text-center">
+          No kids added yet. Add your first child to get started!
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {kids.map((kid) => (
+            <KidCard
+              key={kid.id}
+              profile={kid}
+              onEdit={() => setFormMode({ kind: "edit", profile: kid })}
+            />
+          ))}
+        </div>
+      )}
+
+      {formMode.kind === "create" && (
+        <KidForm
+          mode="create"
+          onSubmit={handleCreate}
+          onCancel={() => setFormMode({ kind: "closed" })}
+        />
+      )}
+      {formMode.kind === "edit" && (
+        <KidForm
+          mode="edit"
+          profile={formMode.profile}
+          onSubmit={(fd) => handleEdit(formMode.profile.id, fd)}
+          onCancel={() => setFormMode({ kind: "closed" })}
+          onDelete={() => handleDelete(formMode.profile.id)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/kids/page.tsx
+++ b/src/app/admin/kids/page.tsx
@@ -1,14 +1,23 @@
-import { Users } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import KidsContent from "@/app/admin/components/KidsContent";
+import type { Database } from "@/types/database";
 
-export default function AdminKidsPage() {
-  return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
-      <Users size={48} className="text-text-secondary mb-4" />
-      <h2 className="text-xl font-bold mb-2">Kids</h2>
-      <p className="text-text-secondary max-w-sm">
-        Child profile management is coming soon. You&apos;ll be able to add kids,
-        change avatars, and manage profiles here.
-      </p>
-    </div>
-  );
+type Profile = Database["public"]["Tables"]["profiles"]["Row"];
+
+export default async function AdminKidsPage() {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("role", "child")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("Failed to load kids:", error.message);
+  }
+
+  const kids = (data ?? []) as Profile[];
+
+  return <KidsContent kids={kids} />;
 }

--- a/src/app/components/CheckInModal.tsx
+++ b/src/app/components/CheckInModal.tsx
@@ -6,18 +6,28 @@ import { recordCheckIn } from "@/app/actions/checkIn";
 import { getAvatarIcon } from "@/lib/avatarUtils";
 import { getRandomLateMessage } from "@/lib/lateMessages";
 import { playCheckInSound } from "@/lib/sounds";
+import type { Json } from "@/types/database";
 
-const CHECKLIST_ITEMS = [
-  { label: "Teeth", emoji: "\u{1FAA5}", bg: "#E8F5E9" },
-  { label: "Clothes", emoji: "\u{1F455}", bg: "#FFF3E0" },
-  { label: "Potty", emoji: "\u{1F6BD}", bg: "#E8F5E9" },
-  { label: "Breakfast", emoji: "\u{1F374}", bg: "#FCE4EC" },
-  { label: "Shoes", emoji: "\u{1F45F}", bg: "#FCE4EC" },
-];
+// Alternating soft background colors for checklist items
+const CHECKLIST_BG_COLORS = ["#E8F5E9", "#FFF3E0", "#FCE4EC", "#E3F2FD", "#F3E5F5"];
+
+type ChecklistItem = { emoji: string; label: string };
+
+/** Parse checklist_items from DB (handles string[], {icon,label}[], and {emoji,label}[]) */
+function parseChecklistItems(raw: Json): ChecklistItem[] {
+  if (!raw || !Array.isArray(raw)) return [];
+  return (raw as (string | Record<string, string>)[]).map((item) => {
+    if (typeof item === "string") return { emoji: "⭐", label: item };
+    if ("emoji" in item) return { emoji: item.emoji, label: item.label };
+    if ("icon" in item) return { emoji: "⭐", label: item.label || "" };
+    return { emoji: "⭐", label: "" };
+  });
+}
 
 interface CheckInModalProps {
   profile: ParticipantProfile;
   goalId: string;
+  checklistItems: Json;
   participants: { profiles: ParticipantProfile }[];
   checkedInProfileIds: string[];
   isLate: boolean;
@@ -31,6 +41,7 @@ interface CheckInModalProps {
 export default function CheckInModal({
   profile,
   goalId,
+  checklistItems: rawChecklistItems,
   participants,
   checkedInProfileIds,
   isLate,
@@ -42,6 +53,7 @@ export default function CheckInModal({
 }: CheckInModalProps) {
   const [isPending, startTransition] = useTransition();
   const alreadyCheckedIn = checkedInProfileIds.includes(profile.id);
+  const [checklistItems] = useState(() => parseChecklistItems(rawChecklistItems));
 
   // Pick a random late message once when the modal mounts
   const [lateMessage] = useState(() =>
@@ -139,20 +151,22 @@ export default function CheckInModal({
           <>
             <p className="text-gray-500 text-center mb-4">Have you done everything?</p>
 
-            {/* Checklist — view-only icons */}
-            <div className="flex justify-center gap-3 mb-6">
-              {CHECKLIST_ITEMS.map((item) => (
-                <div key={item.label} className="flex flex-col items-center gap-1">
-                  <div
-                    className="w-14 h-14 rounded-xl flex items-center justify-center text-2xl"
-                    style={{ backgroundColor: item.bg }}
-                  >
-                    {item.emoji}
+            {/* Checklist — view-only icons from goal config */}
+            {checklistItems.length > 0 && (
+              <div className="flex justify-center gap-3 mb-6 flex-wrap">
+                {checklistItems.map((item, i) => (
+                  <div key={i} className="flex flex-col items-center gap-1">
+                    <div
+                      className="w-14 h-14 rounded-xl flex items-center justify-center text-2xl"
+                      style={{ backgroundColor: CHECKLIST_BG_COLORS[i % CHECKLIST_BG_COLORS.length] }}
+                    >
+                      {item.emoji}
+                    </div>
+                    <span className="text-xs text-gray-500 font-semibold">{item.label}</span>
                   </div>
-                  <span className="text-xs text-gray-500 font-semibold">{item.label}</span>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
 
             {/* Team status bar */}
             <div className="flex flex-col gap-2 mb-6">

--- a/src/app/components/ParticipantAvatars.tsx
+++ b/src/app/components/ParticipantAvatars.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import type { ParticipantProfile } from "@/types/database";
+import type { ParticipantProfile, Json } from "@/types/database";
 import CheckInModal from "./CheckInModal";
 import CelebrationModal from "./CelebrationModal";
 import { getAvatarIcon } from "@/lib/avatarUtils";
@@ -9,6 +9,7 @@ import { getAvatarIcon } from "@/lib/avatarUtils";
 interface ParticipantAvatarsProps {
   participants: { profiles: ParticipantProfile }[];
   goalId: string;
+  checklistItems: Json;
   initialCheckedInProfileIds: string[];
   isLate: boolean;
   isTeam: boolean;
@@ -20,6 +21,7 @@ interface ParticipantAvatarsProps {
 export default function ParticipantAvatars({
   participants,
   goalId,
+  checklistItems,
   initialCheckedInProfileIds,
   isLate,
   isTeam,
@@ -99,6 +101,7 @@ export default function ParticipantAvatars({
         <CheckInModal
           profile={openProfile}
           goalId={goalId}
+          checklistItems={checklistItems}
           participants={participants}
           checkedInProfileIds={checkedInProfileIds}
           isLate={isLate}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,6 +121,7 @@ export default async function DashboardPage() {
           <ParticipantAvatars
             participants={participants}
             goalId={goal.id}
+            checklistItems={goal.checklist_items}
             initialCheckedInProfileIds={checkedInProfileIds}
             isLate={isLate}
             isTeam={goal.is_team}

--- a/src/lib/avatarUtils.ts
+++ b/src/lib/avatarUtils.ts
@@ -1,8 +1,47 @@
+export interface AvatarOption {
+  id: string;
+  emoji: string;
+  label: string;
+}
+
+/** All available avatar choices for kid profiles */
+export const AVATAR_OPTIONS: AvatarOption[] = [
+  { id: "dog", emoji: "\u{1F436}", label: "Dog" },
+  { id: "cat", emoji: "\u{1F431}", label: "Cat" },
+  { id: "bird", emoji: "\u{1F426}", label: "Bird" },
+  { id: "penguin", emoji: "\u{1F427}", label: "Penguin" },
+  { id: "unicorn", emoji: "\u{1F984}", label: "Unicorn" },
+  { id: "fox", emoji: "\u{1F98A}", label: "Fox" },
+  { id: "bunny", emoji: "\u{1F430}", label: "Bunny" },
+  { id: "panda", emoji: "\u{1F43C}", label: "Panda" },
+  { id: "butterfly", emoji: "\u{1F98B}", label: "Butterfly" },
+  { id: "alien", emoji: "\u{1F47D}", label: "Alien" },
+  { id: "robot", emoji: "\u{1F916}", label: "Robot" },
+  { id: "dragon", emoji: "\u{1F409}", label: "Dragon" },
+];
+
+/** Kid-friendly color palette for profile accent colors */
+export const COLOR_PALETTE = [
+  { hex: "#4CAF50", label: "Green" },
+  { hex: "#2196F3", label: "Blue" },
+  { hex: "#E91E63", label: "Pink" },
+  { hex: "#9C27B0", label: "Purple" },
+  { hex: "#FF9800", label: "Orange" },
+  { hex: "#009688", label: "Teal" },
+  { hex: "#F44336", label: "Red" },
+  { hex: "#FFC107", label: "Yellow" },
+  { hex: "#3F51B5", label: "Indigo" },
+  { hex: "#00BCD4", label: "Cyan" },
+];
+
+const avatarMap = new Map(AVATAR_OPTIONS.map((a) => [a.id, a.emoji]));
+
+/** Returns the emoji for an avatar identifier */
 export function getAvatarIcon(avatar: string): string {
-  switch (avatar) {
-    case "bird": return "\u{1F426}";
-    case "dog": return "\u{1F415}";
-    case "cat": return "\u{1F431}";
-    default: return "\u{1F464}";
-  }
+  return avatarMap.get(avatar) ?? "\u{1F464}";
+}
+
+/** Returns the label for an avatar identifier */
+export function getAvatarLabel(avatar: string): string {
+  return AVATAR_OPTIONS.find((a) => a.id === avatar)?.label ?? "Unknown";
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -19,7 +19,7 @@ insert into goals (id, family_id, name, description, checklist_items, target_cou
    'a1b2c3d4-0000-4000-8000-000000000001',
    'Ready for School!',
    'Be fully ready for school before 8:00 AM',
-   '["teeth", "clothes", "shoes", "breakfast", "bathroom"]',
+   '[{"emoji":"🪥","label":"Teeth"},{"emoji":"👕","label":"Clothes"},{"emoji":"👟","label":"Shoes"},{"emoji":"🍴","label":"Breakfast"},{"emoji":"🚽","label":"Bathroom"}]',
    20,
    'Ice Cream Sundae Party',
    '🍨',


### PR DESCRIPTION
## Summary
- **Kids tab**: Functional profile management — list, add, edit, delete child profiles with avatar picker (12 emoji options) and color picker (10 kid-friendly colors)
- **Checklist icon unification**: Replaced disconnected Lucide icon system in GoalForm with emoji picker. CheckInModal now reads checklist items from the goal's DB record instead of hardcoded array — admin edits are reflected in kid-facing UI
- **GoalForm fixes**: Checklist items now populate correctly on edit (handled string array seed format), added prize emoji picker grid
- **Avatar expansion**: 4 → 12 avatar options (dog, cat, bird, penguin, unicorn, fox, bunny, panda, butterfly, alien, robot, dragon)

## Test plan
- [ ] Admin > Kids tab lists existing child profiles with avatar, name, and color
- [ ] "Add Child" opens form with name input, 4x3 avatar grid, color palette
- [ ] Creating a child appears in the list and on the dashboard
- [ ] Editing a child updates name/avatar/color everywhere
- [ ] Delete removes the profile
- [ ] Admin > Goals > Edit shows checklist items populated with emoji
- [ ] Changing checklist emoji in admin reflects on the check-in modal
- [ ] Prize emoji field shows a picker grid instead of plain text input
- [ ] New avatars (penguin, unicorn, fox, etc.) render correctly on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)