### PR TITLE
Add responsive portrait layout with tab toggle

### DIFF
--- a/src/app/components/CalendarGrid.tsx
+++ b/src/app/components/CalendarGrid.tsx
@@ -105,7 +105,7 @@ export default function CalendarGrid({ startDate, entries, timezone }: CalendarG
   const cells = buildCalendarGrid(startDate, entries, timezone);
 
   return (
-    <section className="flex-[2] min-w-0 bg-white rounded-2xl p-5">
+    <section className="min-w-0 bg-white rounded-2xl p-3 md:p-5 h-full">
       {/* Day headers */}
       <div className="grid grid-cols-7 gap-3 mb-2 px-1">
         {["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"].map((day) => (

--- a/src/app/components/DashboardContent.tsx
+++ b/src/app/components/DashboardContent.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+type View = "jar" | "calendar";
+
+interface DashboardContentProps {
+  calendar: React.ReactNode;
+  sidebar: React.ReactNode;
+}
+
+/**
+ * Responsive layout wrapper for the dashboard.
+ * - Wide screens (md+): side-by-side calendar + sidebar (landscape layout)
+ * - Narrow screens (<md): tab toggle between Jar and Calendar views
+ */
+export default function DashboardContent({
+  calendar,
+  sidebar,
+}: DashboardContentProps) {
+  const [activeView, setActiveView] = useState<View>("jar");
+
+  return (
+    <div
+      className="flex-1 flex flex-col md:flex-row gap-4 md:gap-6 p-4 md:p-5"
+      style={{ backgroundColor: "#FAE5D8" }}
+    >
+      {/* Tab switcher — narrow screens only */}
+      <div className="flex md:hidden bg-white rounded-full p-1 gap-1">
+        <button
+          onClick={() => setActiveView("jar")}
+          className="flex-1 py-2 rounded-full text-sm font-bold transition-colors"
+          style={{
+            backgroundColor:
+              activeView === "jar" ? "var(--color-primary)" : "transparent",
+            color:
+              activeView === "jar"
+                ? "var(--color-text-on-primary)"
+                : "var(--color-text-secondary)",
+            minHeight: 36,
+          }}
+        >
+          Jar
+        </button>
+        <button
+          onClick={() => setActiveView("calendar")}
+          className="flex-1 py-2 rounded-full text-sm font-bold transition-colors"
+          style={{
+            backgroundColor:
+              activeView === "calendar" ? "var(--color-primary)" : "transparent",
+            color:
+              activeView === "calendar"
+                ? "var(--color-text-on-primary)"
+                : "var(--color-text-secondary)",
+            minHeight: 36,
+          }}
+        >
+          Calendar
+        </button>
+      </div>
+
+      {/* Calendar — always visible on wide, toggled on narrow */}
+      <div
+        className={`flex-[2] min-w-0 ${
+          activeView === "calendar" ? "block" : "hidden"
+        } md:block`}
+      >
+        {calendar}
+      </div>
+
+      {/* Sidebar (jar + clock + avatars) — always visible on wide, toggled on narrow */}
+      <aside
+        className={`flex-[1] flex flex-col items-center gap-3 ${
+          activeView === "jar" ? "flex" : "hidden"
+        } md:flex`}
+      >
+        {sidebar}
+      </aside>
+    </div>
+  );
+}

--- a/src/app/components/ParticipantAvatars.tsx
+++ b/src/app/components/ParticipantAvatars.tsx
@@ -59,7 +59,7 @@ export default function ParticipantAvatars({
 
   return (
     <>
-      <div className="flex gap-8 mb-3">
+      <div className="flex gap-6 md:gap-8 mb-3">
         {participants.map((p) => {
           const profile = p.profiles;
           if (!profile) return null;
@@ -73,7 +73,7 @@ export default function ParticipantAvatars({
             >
               <div className="relative">
                 <div
-                  className="w-28 h-28 rounded-full flex items-center justify-center text-6xl"
+                  className="w-20 h-20 md:w-28 md:h-28 rounded-full flex items-center justify-center text-4xl md:text-6xl"
                   style={{
                     backgroundColor: profile.color ?? "#ccc",
                   }}

--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -17,16 +17,16 @@ export default function TopBar({
   targetCount,
 }: TopBarProps) {
   return (
-    <header className="bg-primary text-white px-5 py-3 flex items-center gap-4">
-      <h1 className="text-lg font-extrabold tracking-wide mr-2">
+    <header className="bg-primary text-white px-3 md:px-5 py-3 flex items-center gap-2 md:gap-4">
+      <h1 className="text-sm md:text-lg font-extrabold tracking-wide mr-1 md:mr-2">
         {goalName}
       </h1>
       {prizeEmoji && (
-        <span className="bg-white/20 backdrop-blur px-4 py-1.5 text-sm font-bold rounded-full flex items-center gap-1.5">
+        <span className="hidden md:flex bg-white/20 backdrop-blur px-4 py-1.5 text-sm font-bold rounded-full items-center gap-1.5">
           {prizeEmoji} {prizeText}
         </span>
       )}
-      <span className="bg-white/25 px-4 py-1.5 text-base font-extrabold rounded-full ml-auto">
+      <span className="bg-white/25 px-3 md:px-4 py-1.5 text-sm md:text-base font-extrabold rounded-full ml-auto">
         {successCount} / {targetCount}
       </span>
       <MuteButton />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import CalendarGrid from "@/app/components/CalendarGrid";
 import LiveClock from "@/app/components/LiveClock";
 import MarbleJar from "@/app/components/MarbleJar";
 import ParticipantAvatars from "@/app/components/ParticipantAvatars";
+import DashboardContent from "@/app/components/DashboardContent";
 import { ensureDailyEntries } from "@/app/actions/checkIn";
 import { getDateInTimezone, isAfterDeadline } from "@/lib/deadlineUtils";
 
@@ -112,25 +113,28 @@ export default async function DashboardPage() {
         targetCount={goal.target_count}
       />
 
-      <div className="flex-1 flex gap-6 p-5" style={{ backgroundColor: "#FAE5D8" }}>
-        <CalendarGrid startDate={goal.start_date} entries={entries} timezone={goal.timezone} />
-
-        <aside className="flex-[1] flex flex-col items-center gap-3">
-          {goal.deadline_time && <LiveClock />}
-          <MarbleJar successCount={successCount} />
-          <ParticipantAvatars
-            participants={participants}
-            goalId={goal.id}
-            checklistItems={goal.checklist_items}
-            initialCheckedInProfileIds={checkedInProfileIds}
-            isLate={isLate}
-            isTeam={goal.is_team}
-            isTimed={!!goal.deadline_time}
-            successCount={successCount}
-            targetCount={goal.target_count}
-          />
-        </aside>
-      </div>
+      <DashboardContent
+        calendar={
+          <CalendarGrid startDate={goal.start_date} entries={entries} timezone={goal.timezone} />
+        }
+        sidebar={
+          <>
+            {goal.deadline_time && <LiveClock />}
+            <MarbleJar successCount={successCount} />
+            <ParticipantAvatars
+              participants={participants}
+              goalId={goal.id}
+              checklistItems={goal.checklist_items}
+              initialCheckedInProfileIds={checkedInProfileIds}
+              isLate={isLate}
+              isTeam={goal.is_team}
+              isTimed={!!goal.deadline_time}
+              successCount={successCount}
+              targetCount={goal.target_count}
+            />
+          </>
+        }
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- **Portrait/mobile layout**: On narrow screens (<768px), dashboard shows a tab toggle between "Jar" view (clock, marble jar, count, avatars) and "Calendar" view
- **Jar view is default**: Matches PRD user story — jar with count and avatars prominently displayed
- **TopBar responsive**: Hides prize badge on narrow screens, uses compact spacing
- **Avatars scale down**: 80px on mobile vs 112px on desktop
- **Landscape preserved**: Wide screens (768px+) show the existing side-by-side layout unchanged
- **Portrait mockups**: Two new frames added to `designs/bocal-mockups.pen`

## Test plan
- [ ] Desktop/landscape: layout unchanged — calendar left, jar/clock/avatars right
- [ ] Portrait/narrow (resize browser to ~375px): shows "Jar" tab by default with clock, jar, count, avatars
- [ ] Tap "Calendar" tab: shows full calendar grid, "Jar" tab deactivates
- [ ] Tap "Jar" tab: returns to jar view
- [ ] Check-in flow works in portrait — tap avatar, modal opens, check in
- [ ] Touch targets remain ≥44px on mobile
- [ ] TopBar: prize badge hidden on narrow, visible on wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)