### PR TITLE
Fix portrait layout to fit viewport without scrolling

### DIFF
--- a/src/app/components/DashboardContent.tsx
+++ b/src/app/components/DashboardContent.tsx
@@ -22,7 +22,7 @@ export default function DashboardContent({
 
   return (
     <div
-      className="flex-1 flex flex-col md:flex-row gap-4 md:gap-6 p-4 md:p-5"
+      className="flex-1 min-h-0 flex flex-col md:flex-row gap-3 md:gap-6 p-3 md:p-5"
       style={{ backgroundColor: "#FAE5D8" }}
     >
       {/* Tab switcher — narrow screens only */}
@@ -70,7 +70,7 @@ export default function DashboardContent({
 
       {/* Sidebar (jar + clock + avatars) — always visible on wide, toggled on narrow */}
       <aside
-        className={`flex-[1] flex flex-col items-center gap-3 ${
+        className={`flex-[1] min-h-0 flex flex-col items-center gap-2 md:gap-3 ${
           activeView === "jar" ? "flex" : "hidden"
         } md:flex`}
       >

--- a/src/app/components/LiveClock.tsx
+++ b/src/app/components/LiveClock.tsx
@@ -17,12 +17,12 @@ export default function LiveClock() {
 
   if (!now) {
     return (
-      <div className="flex flex-col items-center gap-1">
-        <svg width="240" height="240" viewBox="0 0 120 120">
+      <div className="flex flex-col items-center gap-1 shrink-0">
+        <svg className="w-[100px] h-[100px] md:w-[240px] md:h-[240px]" viewBox="0 0 120 120">
           <circle cx="60" cy="60" r="56" fill="white" stroke="#158068" strokeWidth="2.5" />
           <circle cx="60" cy="60" r="3" fill="#333" />
         </svg>
-        <span className="text-2xl font-bold text-text-secondary">&nbsp;</span>
+        <span className="text-base md:text-2xl font-bold text-text-secondary">&nbsp;</span>
       </div>
     );
   }
@@ -49,8 +49,8 @@ export default function LiveClock() {
   const timeStr = `${displayHours}:${String(minutes).padStart(2, "0")} ${amPm}`;
 
   return (
-    <div className="flex flex-col items-center gap-1">
-      <svg width="240" height="240" viewBox="0 0 120 120">
+    <div className="flex flex-col items-center gap-1 shrink-0">
+      <svg className="w-[100px] h-[100px] md:w-[240px] md:h-[240px]" viewBox="0 0 120 120">
         {/* White background */}
         <circle cx="60" cy="60" r="56" fill="white" stroke="#158068" strokeWidth="2.5" />
         {/* All 12 hour numbers */}
@@ -87,7 +87,7 @@ export default function LiveClock() {
           stroke="#333" strokeWidth="2" strokeLinecap="round"
         />
       </svg>
-      <span className="text-2xl font-bold text-text-secondary">{timeStr}</span>
+      <span className="text-base md:text-2xl font-bold text-text-secondary">{timeStr}</span>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,7 +104,7 @@ export default async function DashboardPage() {
   }
 
   return (
-    <main className="flex-1 flex flex-col min-h-screen">
+    <main className="flex flex-col h-dvh md:min-h-screen md:h-auto overflow-hidden md:overflow-visible">
       <TopBar
         goalName={goal.name}
         prizeEmoji={goal.prize_emoji}


### PR DESCRIPTION
## Summary
- Use `h-dvh` on mobile to lock layout to viewport height — no scrolling
- Flex containers use `min-h-0` so children shrink to fit available space
- Clock scales from 240px (desktop) to 100px (mobile)
- Tighter gaps and padding on narrow screens
- Marble jar fills remaining space between clock and avatars

## Test plan
- [ ] Phone/portrait: jar view fits entirely on screen, no scrolling needed
- [ ] Calendar tab: fits on screen
- [ ] Desktop/landscape: no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)