### PR TITLE
Fix celebration count, check-in status, close buttons, mobile decorations

### DIFF
--- a/src/app/admin/components/KidForm.tsx
+++ b/src/app/admin/components/KidForm.tsx
@@ -99,7 +99,7 @@ export default function KidForm({
         {/* Close button */}
         <button
           onClick={onCancel}
-          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
           aria-label="Close"
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/src/app/components/CalendarGrid.tsx
+++ b/src/app/components/CalendarGrid.tsx
@@ -167,10 +167,11 @@ export default function CalendarGrid({ startDate, entries, timezone }: CalendarG
                       color={palette?.text ?? "#3D9B8F"}
                     />
                   </div>
-                  {/* Decorations scattered freely with organic variation */}
+                  {/* Decorations — hidden on mobile to reduce clutter */}
                   {decos.map((d, i) => (
                     <span
                       key={i}
+                      className="hidden md:inline"
                       style={{
                         position: "absolute",
                         top: `${d.top}%`,

--- a/src/app/components/CelebrationModal.tsx
+++ b/src/app/components/CelebrationModal.tsx
@@ -56,7 +56,7 @@ export default function CelebrationModal({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
           aria-label="Close"
         >
           <svg

--- a/src/app/components/CheckInModal.tsx
+++ b/src/app/components/CheckInModal.tsx
@@ -100,10 +100,10 @@ export default function CheckInModal({
         style={{ boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)" }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Close button — 44x44px minimum touch target */}
+        {/* Close button — visible circle with X, 44x44px touch target */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          className="absolute top-4 right-4 w-11 h-11 flex items-center justify-center rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
           aria-label="Close"
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -187,7 +187,11 @@ export default function CheckInModal({
                     >
                       {getAvatarIcon(member.avatar)}
                     </div>
-                    {isCurrentKid ? (
+                    {isCurrentKid && alreadyCheckedIn ? (
+                      <span className="text-sm font-bold text-gray-700">
+                        {member.name}: checked in &#10003;
+                      </span>
+                    ) : isCurrentKid ? (
                       <span
                         className="text-sm font-bold px-3 py-1 rounded-full text-white"
                         style={{ backgroundColor: member.color ?? "#ccc" }}

--- a/src/app/components/ParticipantAvatars.tsx
+++ b/src/app/components/ParticipantAvatars.tsx
@@ -116,7 +116,7 @@ export default function ParticipantAvatars({
       {showCelebration && (
         <CelebrationModal
           participants={participants}
-          successCount={successCount + 1}
+          successCount={successCount}
           targetCount={targetCount}
           isTeam={isTeam}
           onClose={handleCloseCelebration}


### PR DESCRIPTION
## Summary
- **Celebration modal count**: Removed incorrect `+1` offset — was showing 5/20 instead of 4/20
- **Check-in modal status**: Shows "checked in ✓" for the current user when they've already checked in, instead of misleading "checking in now"
- **Modal close buttons**: All modals (CheckInModal, CelebrationModal, KidForm) now have a visible gray circle background on the X button for better discoverability and touch accuracy
- **Mobile calendar decorations**: Hidden on narrow screens (`hidden md:inline`) to reduce clutter and improve readability

## Test plan
- [ ] Celebration modal shows correct count (same as TopBar)
- [ ] After checking in, tapping avatar shows "checked in ✓" for both kids
- [ ] Modal close buttons have visible gray circle background, easy to tap
- [ ] Mobile calendar: no emoji decorations on success days
- [ ] Desktop calendar: decorations still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)