### PR TITLE
Scale marble jar to goal target count

### DIFF
--- a/src/app/components/MarbleJar.tsx
+++ b/src/app/components/MarbleJar.tsx
@@ -9,41 +9,95 @@ const MARBLE_COLORS = [
   "#34D399", "#F472B6", "#5B9BD5", "#FF9A9E", "#C084FC",
 ];
 
-/* ── Generate marble positions inside jar (viewbox 160×180, supports up to 30+) ── */
-/* Jar walls: left ~36-50px, right ~110-124px depending on height.
-   Marbles (r=9) must stay fully inside: cx must be ≥ wall+11, ≤ wall-11. */
-function getMarblePositions(count: number) {
-  const STEP_X = 16;
-  const STEP_Y = 16;
-  const CENTER = 80;
-  const BOTTOM = 158;
-  // Hex-packed rows, tapering toward the narrower neck
-  const rowCapacities = [5, 4, 5, 4, 4, 4, 3, 2]; // 31 total capacity
+/* ── Jar inner width at a given y position (from SVG path shape) ── */
+function jarInnerWidth(y: number): number {
+  if (y >= 140) return 82;
+  if (y >= 110) return 80;
+  if (y >= 80) return 74;
+  if (y >= 60) return 64;
+  return 54;
+}
 
+/**
+ * Dynamically compute marble size and row layout so that exactly
+ * `targetCount` marbles fill the jar. Starts with the largest marble
+ * size that fits and shrinks until all marbles fit within the jar shape.
+ */
+function computeLayout(targetCount: number) {
+  const CENTER = 80;
+  const BOTTOM = 160;
+  const MIN_Y = 42;
+
+  let r = 10;
+  let stepX: number;
+  let stepY: number;
+  let rowCaps: number[] = [];
+
+  // Shrink marble radius until targetCount fits inside the jar
+  while (r >= 4) {
+    stepX = Math.ceil(r * 2.15);
+    stepY = Math.ceil(r * 2.15);
+    rowCaps = [];
+    let total = 0;
+    let y = BOTTOM;
+    while (y >= MIN_Y && total < targetCount) {
+      const w = jarInnerWidth(y);
+      const cap = Math.max(1, Math.floor((w - r) / stepX) + 1);
+      rowCaps.push(cap);
+      total += cap;
+      y -= stepY;
+    }
+    if (total >= targetCount) break;
+    r -= 0.5;
+  }
+
+  // Trim excess from the last row so total === targetCount
+  let total = rowCaps.reduce((a, b) => a + b, 0);
+  while (total > targetCount && rowCaps.length > 0) {
+    const last = rowCaps[rowCaps.length - 1];
+    const excess = total - targetCount;
+    if (excess >= last) {
+      rowCaps.pop();
+      total -= last;
+    } else {
+      rowCaps[rowCaps.length - 1] -= excess;
+      total = targetCount;
+    }
+  }
+
+  return { radius: r, stepX: Math.ceil(r * 2.15), stepY: Math.ceil(r * 2.15), rowCaps, center: CENTER, bottom: BOTTOM };
+}
+
+function getMarblePositions(count: number, targetCount: number) {
+  const { radius, stepX, stepY, rowCaps, center, bottom } = computeLayout(targetCount);
   const positions: { cx: number; cy: number }[] = [];
   let placed = 0;
 
-  for (let row = 0; row < rowCapacities.length && placed < count; row++) {
-    const cap = rowCapacities[row];
+  for (let row = 0; row < rowCaps.length && placed < count; row++) {
+    const cap = rowCaps[row];
     const toPlace = Math.min(cap, count - placed);
-    const y = BOTTOM - row * STEP_Y;
+    const y = bottom - row * stepY;
     for (let col = 0; col < toPlace; col++) {
-      const x = CENTER + (col - (toPlace - 1) / 2) * STEP_X;
+      const x = center + (col - (toPlace - 1) / 2) * stepX;
       positions.push({ cx: x, cy: y });
     }
     placed += toPlace;
   }
 
-  return positions;
+  return { positions, radius };
 }
 
 interface MarbleJarProps {
   successCount: number;
+  targetCount: number;
 }
 
-export default function MarbleJar({ successCount }: MarbleJarProps) {
+export default function MarbleJar({ successCount, targetCount }: MarbleJarProps) {
   const prevCountRef = useRef<number | null>(null);
-  const marblePositions = useMemo(() => getMarblePositions(successCount), [successCount]);
+  const { positions: marblePositions, radius } = useMemo(
+    () => getMarblePositions(successCount, targetCount),
+    [successCount, targetCount]
+  );
 
   // Detect new marbles inside the effect to avoid stale closure issues
   const isNewMarble = prevCountRef.current !== null && successCount > prevCountRef.current;
@@ -79,8 +133,8 @@ export default function MarbleJar({ successCount }: MarbleJarProps) {
               className={isLast ? "animate-marble-drop" : undefined}
               style={isLast ? { transformBox: "fill-box" as const, transformOrigin: "center" } : undefined}
             >
-              <circle cx={pos.cx} cy={pos.cy} r="9" fill={MARBLE_COLORS[i % MARBLE_COLORS.length]} />
-              <circle cx={pos.cx - 3} cy={pos.cy - 3} r="2.5" fill="rgba(255,255,255,0.4)" />
+              <circle cx={pos.cx} cy={pos.cy} r={radius} fill={MARBLE_COLORS[i % MARBLE_COLORS.length]} />
+              <circle cx={pos.cx - radius * 0.3} cy={pos.cy - radius * 0.3} r={radius * 0.28} fill="rgba(255,255,255,0.4)" />
             </g>
           );
         })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,7 +120,7 @@ export default async function DashboardPage() {
         sidebar={
           <>
             {goal.deadline_time && <LiveClock />}
-            <MarbleJar successCount={successCount} />
+            <MarbleJar successCount={successCount} targetCount={goal.target_count} />
             <ParticipantAvatars
               participants={participants}
               goalId={goal.id}


### PR DESCRIPTION
## Summary
- MarbleJar now accepts `targetCount` prop and dynamically sizes marbles
- Starts with large marbles (r=10) for small targets, shrinks to r=4 for targets up to 50+
- Row capacities computed from the jar's SVG shape at each height level
- Jar visually fills completely when `successCount === targetCount`

## Test plan
- [ ] With target 20: marbles are a comfortable size, jar fills at 20
- [ ] With target 10: larger marbles, fewer rows
- [ ] With target 50: smaller marbles, more rows, all fit inside jar
- [ ] Marble drop animation still works on new marble

🤖 Generated with [Claude Code](https://claude.com/claude-code)