### PR TITLE
Fix marble boundaries, goal navigation, entry resets, and pre-selection

### DIFF
--- a/src/app/actions/checkIn.ts
+++ b/src/app/actions/checkIn.ts
@@ -181,20 +181,23 @@ export async function ensureDailyEntries(goalId: string) {
   const dayOfWeek = getDayOfWeekInTimezone(now, tz);
   const activeDays = (goal.active_days as number[]) ?? [];
 
-  // Create today's entry if it's an active day and doesn't exist yet
+  // Create today's entry if it's an active day and doesn't exist yet.
+  // If the deadline has already passed, create as "miss" directly
+  // (avoids creating "pending" only to immediately transition it).
   if (activeDays.includes(dayOfWeek) && today >= goal.start_date) {
     const { data: todayEntry } = await supabase
       .from("daily_entries")
-      .select("id")
+      .select("id, status")
       .eq("goal_id", goalId)
       .eq("date", today)
       .maybeSingle();
 
     if (!todayEntry) {
+      const pastDeadline = isAfterDeadline(now, goal.deadline_time, tz);
       await supabase.from("daily_entries").insert({
         goal_id: goalId,
         date: today,
-        status: "pending" as const,
+        status: (pastDeadline ? "miss" : "pending") as "miss" | "pending",
       });
     }
   }

--- a/src/app/admin/components/EntriesContent.tsx
+++ b/src/app/admin/components/EntriesContent.tsx
@@ -13,13 +13,19 @@ type DailyEntry = Database["public"]["Tables"]["daily_entries"]["Row"];
 interface EntriesContentProps {
   goals: Goal[];
   entriesByGoal: Record<string, DailyEntry[]>;
+  initialGoalId?: string;
 }
 
 export default function EntriesContent({
   goals,
   entriesByGoal,
+  initialGoalId,
 }: EntriesContentProps) {
-  const [selectedGoalId, setSelectedGoalId] = useState(goals[0]?.id ?? "");
+  const [selectedGoalId, setSelectedGoalId] = useState(
+    initialGoalId && goals.some((g) => g.id === initialGoalId)
+      ? initialGoalId
+      : goals[0]?.id ?? ""
+  );
   const [isSkipping, startSkipTransition] = useTransition();
 
   const selectedGoal = goals.find((g) => g.id === selectedGoalId);

--- a/src/app/admin/components/GoalCard.tsx
+++ b/src/app/admin/components/GoalCard.tsx
@@ -157,7 +157,7 @@ export default function GoalCard({
               label="Skip Today"
             />
             <ActionButton
-              onClick={() => router.push("/admin/entries")}
+              onClick={() => router.push(`/admin/entries?goal=${goal.id}`)}
               icon={FileEdit}
               label="Correct Entry"
             />

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -5,7 +5,12 @@ import type { Database } from "@/types/database";
 type Goal = Database["public"]["Tables"]["goals"]["Row"];
 type DailyEntry = Database["public"]["Tables"]["daily_entries"]["Row"];
 
-export default async function AdminEntriesPage() {
+export default async function AdminEntriesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ goal?: string }>;
+}) {
+  const params = await searchParams;
   const supabase = await createClient();
 
   // Fetch all goals (active + completed) for the goal picker
@@ -42,5 +47,5 @@ export default async function AdminEntriesPage() {
     }
   }
 
-  return <EntriesContent goals={goals} entriesByGoal={entriesByGoal} />;
+  return <EntriesContent goals={goals} entriesByGoal={entriesByGoal} initialGoalId={params.goal} />;
 }

--- a/src/app/components/GoalSelector.tsx
+++ b/src/app/components/GoalSelector.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface GoalSelectorProps {
+  goals: { id: string; name: string }[];
+  currentGoalId: string;
+}
+
+/**
+ * Dropdown to switch between active goals on the dashboard.
+ * Only renders when there are multiple goals.
+ */
+export default function GoalSelector({ goals, currentGoalId }: GoalSelectorProps) {
+  const router = useRouter();
+
+  if (goals.length <= 1) return null;
+
+  return (
+    <select
+      value={currentGoalId}
+      onChange={(e) => router.push(`/?goal=${e.target.value}`)}
+      className="bg-white/20 text-white text-sm md:text-base font-extrabold rounded-full px-3 py-1.5 appearance-none cursor-pointer"
+      style={{ minHeight: 36 }}
+      aria-label="Select goal"
+    >
+      {goals.map((g) => (
+        <option key={g.id} value={g.id} className="text-gray-800">
+          {g.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/components/MarbleJar.tsx
+++ b/src/app/components/MarbleJar.tsx
@@ -10,12 +10,14 @@ const MARBLE_COLORS = [
 ];
 
 /* ── Jar inner width at a given y position (from SVG path shape) ── */
+/* Jar walls: bottom ~x=40-120, middle ~x=42-118, neck ~x=48-112.
+   Subtract 2*radius margin so marbles stay fully inside the walls. */
 function jarInnerWidth(y: number): number {
-  if (y >= 140) return 82;
-  if (y >= 110) return 80;
-  if (y >= 80) return 74;
-  if (y >= 60) return 64;
-  return 54;
+  if (y >= 150) return 68; // very bottom, walls at ~42-118
+  if (y >= 120) return 70; // lower body
+  if (y >= 90) return 66;  // middle
+  if (y >= 60) return 56;  // upper body, narrowing
+  return 46;               // near neck
 }
 
 /**

--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import MuteButton from "./MuteButton";
+import GoalSelector from "./GoalSelector";
 
 interface TopBarProps {
   goalName: string;
@@ -7,6 +8,8 @@ interface TopBarProps {
   prizeText: string | null;
   successCount: number;
   targetCount: number;
+  activeGoals?: { id: string; name: string }[];
+  currentGoalId?: string;
 }
 
 export default function TopBar({
@@ -15,12 +18,20 @@ export default function TopBar({
   prizeText,
   successCount,
   targetCount,
+  activeGoals,
+  currentGoalId,
 }: TopBarProps) {
+  const hasMultipleGoals = activeGoals && activeGoals.length > 1 && currentGoalId;
+
   return (
     <header className="bg-primary text-white px-3 md:px-5 py-3 flex items-center gap-2 md:gap-4">
-      <h1 className="text-sm md:text-lg font-extrabold tracking-wide mr-1 md:mr-2">
-        {goalName}
-      </h1>
+      {hasMultipleGoals ? (
+        <GoalSelector goals={activeGoals} currentGoalId={currentGoalId} />
+      ) : (
+        <h1 className="text-sm md:text-lg font-extrabold tracking-wide mr-1 md:mr-2">
+          {goalName}
+        </h1>
+      )}
       {prizeEmoji && (
         <span className="hidden md:flex bg-white/20 backdrop-blur px-4 py-1.5 text-sm font-bold rounded-full items-center gap-1.5">
           {prizeEmoji} {prizeText}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,21 +13,43 @@ import { getDateInTimezone, isAfterDeadline } from "@/lib/deadlineUtils";
 type Goal = Database["public"]["Tables"]["goals"]["Row"];
 type DailyEntry = Database["public"]["Tables"]["daily_entries"]["Row"];
 
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ goal?: string }>;
+}) {
   const supabase = await createClient();
+  const params = await searchParams;
 
-  const { data: goalData, error: goalError } = await supabase
+  // Fetch all active goals for the goal selector
+  const { data: allGoals, error: goalsError } = await supabase
     .from("goals")
-    .select("*")
+    .select("id, name")
     .eq("status", "active")
-    .limit(1)
-    .single();
+    .order("created_at", { ascending: true });
 
-  if (goalError && goalError.code !== "PGRST116") {
-    console.error("Failed to load goal:", goalError.message);
+  if (goalsError) {
+    console.error("Failed to load goals:", goalsError.message);
   }
 
-  const goal = goalData as Goal | null;
+  const activeGoals = (allGoals ?? []) as { id: string; name: string }[];
+
+  // Select goal: from URL param, or first active goal
+  const selectedGoalId = params.goal && activeGoals.some((g) => g.id === params.goal)
+    ? params.goal
+    : activeGoals[0]?.id;
+
+  let goal: Goal | null = null;
+  if (selectedGoalId) {
+    const { data: goalData, error: goalError } = await supabase
+      .from("goals")
+      .select("*")
+      .eq("id", selectedGoalId)
+      .single();
+
+    if (goalError) console.error("Failed to load goal:", goalError.message);
+    goal = goalData as Goal | null;
+  }
 
   let participants: { profiles: ParticipantProfile }[] = [];
   let entries: DailyEntry[] = [];
@@ -111,6 +133,8 @@ export default async function DashboardPage() {
         prizeText={goal.prize_text}
         successCount={successCount}
         targetCount={goal.target_count}
+        activeGoals={activeGoals}
+        currentGoalId={goal.id}
       />
 
       <DashboardContent


### PR DESCRIPTION
## Summary
1. **Marbles stay inside jar**: Tightened `jarInnerWidth` values to match actual SVG wall positions
2. **Entry reset prevention**: When deadline has already passed, new entries are created as "miss" directly instead of "pending" (which would immediately transition to "miss" on next load, potentially conflicting with admin edits)
3. **Goal navigation**: Dashboard accepts `?goal=<id>` search param. TopBar shows a dropdown selector when multiple active goals exist
4. **Correct Entry pre-selects goal**: "Correct Entry" button on goal cards passes `?goal=<id>` to Edit Entries page, which pre-selects the clicked goal

## Test plan
- [ ] Marbles render inside jar boundaries at various target counts
- [ ] With 2+ active goals: dropdown appears in TopBar, switching goals updates the dashboard
- [ ] Clicking "Correct Entry" on a goal card opens Edit Entries with that goal selected
- [ ] After editing an entry to "success" via admin, refreshing dashboard doesn't reset it
- [ ] New entries past deadline are created as "miss" (not "pending" then "miss")

🤖 Generated with [Claude Code](https://claude.com/claude-code)