### PR TITLE
Daily entry lifecycle: tests + missed-day fix + calendar scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1229,10 +1230,308 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1624,6 +1923,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2248,6 +2565,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2481,6 +2911,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2690,6 +3130,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3088,6 +3538,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3592,6 +4049,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3600,6 +4067,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3741,6 +4218,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5354,6 +5846,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5459,6 +5962,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5695,6 +6205,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
     "node_modules/run-parallel": {
@@ -5998,6 +6542,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6011,6 +6562,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6234,6 +6799,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6280,6 +6862,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6570,6 +7162,192 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6673,6 +7451,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.0",
@@ -24,6 +26,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import EntriesContent from "@/app/admin/components/EntriesContent";
+import { bootstrapDailyEntries } from "@/lib/dailyEntryLifecycle";
 import type { Database } from "@/types/database";
 
 type Goal = Database["public"]["Tables"]["goals"]["Row"];
@@ -25,6 +26,16 @@ export default async function AdminEntriesPage({
   }
 
   const goals = (goalData ?? []) as Goal[];
+
+  // Back-fill any missing past entries before reading them, so the admin
+  // sees a complete history even on goals where the dashboard wasn't opened.
+  if (goals.length > 0) {
+    await Promise.all(
+      goals
+        .filter((g) => g.status === "active")
+        .map((g) => bootstrapDailyEntries(supabase, g.id))
+    );
+  }
 
   // Fetch entries for all goals in parallel
   const entriesByGoal: Record<string, DailyEntry[]> = {};

--- a/src/app/components/CalendarGrid.tsx
+++ b/src/app/components/CalendarGrid.tsx
@@ -105,9 +105,9 @@ export default function CalendarGrid({ startDate, entries, timezone }: CalendarG
   const cells = buildCalendarGrid(startDate, entries, timezone);
 
   return (
-    <section className="min-w-0 bg-white rounded-2xl p-3 md:p-5 h-full">
-      {/* Day headers */}
-      <div className="grid grid-cols-7 gap-3 mb-2 px-1">
+    <section className="min-w-0 bg-white rounded-2xl h-full flex flex-col">
+      {/* Day headers — fixed at top of card */}
+      <div className="grid grid-cols-7 gap-3 px-4 md:px-6 pt-3 md:pt-5 pb-2">
         {["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"].map((day) => (
           <div
             key={day}
@@ -122,8 +122,9 @@ export default function CalendarGrid({ startDate, entries, timezone }: CalendarG
         ))}
       </div>
 
-      {/* Calendar grid */}
-      <div className="grid grid-cols-7 gap-3">
+      {/* Calendar grid — scrolls vertically when calendar grows tall */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 md:px-5 pb-3 md:pb-5">
+        <div className="grid grid-cols-7 gap-3">
         {cells.map((cell) => {
           const entry = cell.entry;
           const isSuccess = entry?.status === "success";
@@ -203,6 +204,7 @@ export default function CalendarGrid({ startDate, entries, timezone }: CalendarG
             </div>
           );
         })}
+        </div>
       </div>
     </section>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,7 +126,7 @@ export default async function DashboardPage({
   }
 
   return (
-    <main className="flex flex-col h-dvh md:min-h-screen md:h-auto overflow-hidden md:overflow-visible">
+    <main className="flex flex-col h-dvh overflow-hidden">
       <TopBar
         goalName={goal.name}
         prizeEmoji={goal.prize_emoji}

--- a/src/lib/__tests__/dailyEntryLifecycle.test.ts
+++ b/src/lib/__tests__/dailyEntryLifecycle.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the Daily Entry Lifecycle module.
+ *
+ * Each test describes a BEHAVIOR the module must guarantee,
+ * phrased as an acceptance criterion a PM would recognize.
+ * The tests use a mock Supabase client (in-memory data)
+ * so they run instantly with no database.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createMockSupabase } from "./mockSupabase";
+import {
+  recalculateSuccessNumbers,
+  transitionEntryStatus,
+  bootstrapDailyEntries,
+  evaluateTeamCompletion,
+  skipDay,
+} from "../dailyEntryLifecycle";
+
+// ── Test helpers ──
+
+const GOAL_ID = "goal-1";
+
+/** Create a daily entry with sensible defaults */
+function entry(overrides: Record<string, unknown>) {
+  return {
+    id: `entry-${Math.random().toString(36).slice(2, 7)}`,
+    goal_id: GOAL_ID,
+    status: "pending",
+    success_number: null,
+    decoration_seed: null,
+    updated_by: "system",
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── Behavior: Success numbers are always sequential ──
+
+describe("success number sequencing", () => {
+  it("renumbers successes sequentially by date with no gaps", async () => {
+    // GIVEN: 3 successes with incorrect/stale numbering
+    const db = createMockSupabase({
+      daily_entries: [
+        entry({ id: "e1", date: "2026-03-23", status: "success", success_number: 1 }),
+        entry({ id: "e2", date: "2026-03-24", status: "miss" }),
+        entry({ id: "e3", date: "2026-03-25", status: "success", success_number: 3 }), // gap!
+        entry({ id: "e4", date: "2026-03-26", status: "success", success_number: 5 }), // wrong!
+      ],
+    });
+
+    // WHEN: we recalculate success numbers
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await recalculateSuccessNumbers(db as any, GOAL_ID);
+
+    // THEN: successes are numbered 1, 2, 3 sequentially by date
+    const entries = db.getRows("daily_entries");
+    const successes = entries
+      .filter((e) => e.status === "success")
+      .sort((a, b) => String(a.date).localeCompare(String(b.date)));
+
+    expect(successes).toHaveLength(3);
+    expect(successes[0].success_number).toBe(1); // March 23
+    expect(successes[1].success_number).toBe(2); // March 25 (was 3)
+    expect(successes[2].success_number).toBe(3); // March 26 (was 5)
+  });
+});
+
+// ── Behavior: Admin edits are never overwritten ──
+
+describe("bootstrap respects admin edits", () => {
+  it("does not overwrite an admin-edited pending entry to miss", async () => {
+    // GIVEN: A goal with an 8am deadline (now past), and today's entry
+    // was manually set to "pending" by an admin (e.g., parent reset it
+    // because a kid clicked by mistake)
+    const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
+    const dayOfWeek = new Date().getDay(); // 0=Sun, 1=Mon, ...
+
+    const db = createMockSupabase({
+      goals: [
+        {
+          id: GOAL_ID,
+          active_days: [0, 1, 2, 3, 4, 5, 6], // every day is active
+          deadline_time: "08:00:00",
+          start_date: "2026-01-01",
+          timezone: "America/Los_Angeles",
+        },
+      ],
+      daily_entries: [
+        entry({
+          id: "today-entry",
+          date: today,
+          status: "pending",
+          updated_by: "admin", // parent deliberately set this
+        }),
+      ],
+    });
+
+    // WHEN: bootstrap runs (as it does on every page load)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await bootstrapDailyEntries(db as any, GOAL_ID);
+
+    // THEN: the entry should still be "pending" — NOT changed to "miss"
+    const entries = db.getRows("daily_entries");
+    const todayEntry = entries.find((e) => e.id === "today-entry");
+    expect(todayEntry?.status).toBe("pending");
+    expect(todayEntry?.updated_by).toBe("admin");
+  });
+});
+
+// ── Behavior: Status transitions clear/set success fields ──
+
+describe("status transition side effects", () => {
+  it("clears success_number and decoration_seed when changing from success to miss", async () => {
+    // GIVEN: an entry that is currently a success with marble #2
+    const db = createMockSupabase({
+      daily_entries: [
+        entry({ id: "e1", date: "2026-03-23", status: "success", success_number: 1, decoration_seed: 1234 }),
+        entry({ id: "e2", date: "2026-03-24", status: "success", success_number: 2, decoration_seed: 5678 }),
+      ],
+    });
+
+    // WHEN: admin changes e2 from success to miss
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await transitionEntryStatus(db as any, "e2", GOAL_ID, "miss");
+
+    // THEN: e2's success fields are cleared
+    const entries = db.getRows("daily_entries");
+    const e2 = entries.find((e) => e.id === "e2");
+    expect(e2?.status).toBe("miss");
+    expect(e2?.success_number).toBeNull();
+    expect(e2?.decoration_seed).toBeNull();
+
+    // AND: e1 remains success #1 (still numbered correctly)
+    const e1 = entries.find((e) => e.id === "e1");
+    expect(e1?.success_number).toBe(1);
+  });
+
+  it("assigns a decoration_seed when changing to success", async () => {
+    const db = createMockSupabase({
+      daily_entries: [
+        entry({ id: "e1", date: "2026-03-23", status: "miss", decoration_seed: null }),
+      ],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await transitionEntryStatus(db as any, "e1", GOAL_ID, "success");
+
+    const e1 = db.getRows("daily_entries").find((e) => e.id === "e1");
+    expect(e1?.status).toBe("success");
+    expect(e1?.decoration_seed).not.toBeNull();
+    expect(typeof e1?.decoration_seed).toBe("number");
+  });
+
+  it("marks entry as admin-edited on status change", async () => {
+    const db = createMockSupabase({
+      daily_entries: [
+        entry({ id: "e1", date: "2026-03-23", status: "miss", updated_by: "system" }),
+      ],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await transitionEntryStatus(db as any, "e1", GOAL_ID, "success");
+
+    const e1 = db.getRows("daily_entries").find((e) => e.id === "e1");
+    expect(e1?.updated_by).toBe("admin");
+  });
+});
+
+// ── Behavior: Team completion requires ALL members ──
+
+describe("team completion evaluation", () => {
+  it("returns pending when not all team members have checked in", async () => {
+    const db = createMockSupabase({
+      goal_participants: [
+        { goal_id: GOAL_ID, profile_id: "lily" },
+        { goal_id: GOAL_ID, profile_id: "emma" },
+      ],
+      check_ins: [
+        // Only Lily checked in on time
+        { profile_id: "lily", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T07:45:00-07:00" },
+      ],
+      daily_entries: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await evaluateTeamCompletion(db as any, GOAL_ID, true, "08:00:00", "2026-03-23", "America/Los_Angeles");
+
+    expect(result).toBe("pending");
+  });
+
+  it("returns success when all team members have checked in on time", async () => {
+    const db = createMockSupabase({
+      goal_participants: [
+        { goal_id: GOAL_ID, profile_id: "lily" },
+        { goal_id: GOAL_ID, profile_id: "emma" },
+      ],
+      check_ins: [
+        { profile_id: "lily", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T07:45:00-07:00" },
+        { profile_id: "emma", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T07:50:00-07:00" },
+      ],
+      daily_entries: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await evaluateTeamCompletion(db as any, GOAL_ID, true, "08:00:00", "2026-03-23", "America/Los_Angeles");
+
+    expect(result).toBe("success");
+  });
+
+  it("excludes late check-ins from team completion", async () => {
+    const db = createMockSupabase({
+      goal_participants: [
+        { goal_id: GOAL_ID, profile_id: "lily" },
+        { goal_id: GOAL_ID, profile_id: "emma" },
+      ],
+      check_ins: [
+        { profile_id: "lily", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T07:45:00-07:00" }, // on time
+        { profile_id: "emma", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T08:15:00-07:00" }, // LATE
+      ],
+      daily_entries: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await evaluateTeamCompletion(db as any, GOAL_ID, true, "08:00:00", "2026-03-23", "America/Los_Angeles");
+
+    // Emma was late, so team goal is NOT complete
+    expect(result).toBe("pending");
+  });
+
+  it("returns success for individual goal when any member checks in on time", async () => {
+    const db = createMockSupabase({
+      goal_participants: [
+        { goal_id: GOAL_ID, profile_id: "lily" },
+        { goal_id: GOAL_ID, profile_id: "emma" },
+      ],
+      check_ins: [
+        // Only Lily checked in, but that's enough for individual
+        { profile_id: "lily", goal_id: GOAL_ID, date: "2026-03-23", checked_in_at: "2026-03-23T07:45:00-07:00" },
+      ],
+      daily_entries: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await evaluateTeamCompletion(db as any, GOAL_ID, false, "08:00:00", "2026-03-23", "America/Los_Angeles");
+
+    // Individual goal: one on-time check-in is enough
+    expect(result).toBe("success");
+  });
+});
+
+// ── Behavior: Skip day ──
+
+describe("skip day", () => {
+  it("marks a day as skip and recalculates success numbers", async () => {
+    const db = createMockSupabase({
+      daily_entries: [
+        entry({ id: "e1", date: "2026-03-23", status: "success", success_number: 1, decoration_seed: 1111 }),
+        entry({ id: "e2", date: "2026-03-24", status: "success", success_number: 2, decoration_seed: 2222 }),
+        entry({ id: "e3", date: "2026-03-25", status: "miss" }),
+      ],
+    });
+
+    // Skip March 24 (was success #2)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await skipDay(db as any, GOAL_ID, "2026-03-24");
+
+    const entries = db.getRows("daily_entries");
+    const e2 = entries.find((e) => e.id === "e2");
+    expect(e2?.status).toBe("skip");
+    expect(e2?.updated_by).toBe("admin");
+
+    // e1 should now be the only success, numbered #1
+    const e1 = entries.find((e) => e.id === "e1");
+    expect(e1?.success_number).toBe(1);
+  });
+});

--- a/src/lib/__tests__/dailyEntryLifecycle.test.ts
+++ b/src/lib/__tests__/dailyEntryLifecycle.test.ts
@@ -249,6 +249,125 @@ describe("team completion evaluation", () => {
   });
 });
 
+// ── Behavior: Bootstrap back-fills missed days ──
+
+describe("bootstrap back-fills past active days", () => {
+  it("inserts a 'miss' entry for every past active day with no entry", async () => {
+    // GIVEN: a goal that started 5 days ago, every day is active, and only
+    // one of those past days has an entry (a manual success). The other
+    // four past active days have no entry — as if the app was never opened.
+    const today = new Date().toLocaleDateString("en-CA", {
+      timeZone: "America/Los_Angeles",
+    });
+    const [ty, tm, td] = today.split("-").map(Number);
+
+    function dateOffset(days: number): string {
+      const d = new Date(ty, tm - 1, td + days);
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      return `${y}-${m}-${dd}`;
+    }
+
+    const fiveDaysAgo = dateOffset(-5);
+    const threeDaysAgo = dateOffset(-3);
+
+    const db = createMockSupabase({
+      goals: [
+        {
+          id: GOAL_ID,
+          active_days: [0, 1, 2, 3, 4, 5, 6],
+          deadline_time: "08:00:00",
+          start_date: fiveDaysAgo,
+          timezone: "America/Los_Angeles",
+        },
+      ],
+      daily_entries: [
+        // Only one past day has an entry (manually marked success)
+        entry({
+          id: "manual-success",
+          date: threeDaysAgo,
+          status: "success",
+          updated_by: "admin",
+        }),
+      ],
+    });
+
+    // WHEN: bootstrap runs
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await bootstrapDailyEntries(db as any, GOAL_ID);
+
+    // THEN: every day from start through today has an entry
+    const entries = db.getRows("daily_entries");
+    const dates = new Set(entries.map((e) => e.date));
+    for (let i = -5; i <= 0; i++) {
+      expect(dates.has(dateOffset(i))).toBe(true);
+    }
+
+    // AND: the previously empty past days are "miss"
+    const missDates = entries
+      .filter((e) => e.status === "miss")
+      .map((e) => e.date)
+      .sort();
+    expect(missDates).toContain(dateOffset(-5));
+    expect(missDates).toContain(dateOffset(-4));
+    expect(missDates).toContain(dateOffset(-2));
+    expect(missDates).toContain(dateOffset(-1));
+
+    // AND: the admin's manual success is preserved
+    const preserved = entries.find((e) => e.id === "manual-success");
+    expect(preserved?.status).toBe("success");
+    expect(preserved?.updated_by).toBe("admin");
+  });
+
+  it("skips inactive weekdays when back-filling", async () => {
+    // GIVEN: a weekdays-only goal that started 9 days ago — weekend days
+    // in that range should NOT get back-fill entries
+    const today = new Date().toLocaleDateString("en-CA", {
+      timeZone: "America/Los_Angeles",
+    });
+    const [ty, tm, td] = today.split("-").map(Number);
+
+    function dateAt(offset: number): { date: string; dow: number } {
+      const d = new Date(ty, tm - 1, td + offset);
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      return { date: `${y}-${m}-${dd}`, dow: d.getDay() };
+    }
+
+    const startDate = dateAt(-9).date;
+
+    const db = createMockSupabase({
+      goals: [
+        {
+          id: GOAL_ID,
+          active_days: [1, 2, 3, 4, 5], // Mon-Fri only
+          deadline_time: "08:00:00",
+          start_date: startDate,
+          timezone: "America/Los_Angeles",
+        },
+      ],
+      daily_entries: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await bootstrapDailyEntries(db as any, GOAL_ID);
+
+    // THEN: no entries exist for weekend dates in the range
+    const entries = db.getRows("daily_entries");
+    for (let i = -9; i <= 0; i++) {
+      const { date, dow } = dateAt(i);
+      const entry = entries.find((e) => e.date === date);
+      if (dow === 0 || dow === 6) {
+        expect(entry).toBeUndefined();
+      } else {
+        expect(entry).toBeDefined();
+      }
+    }
+  });
+});
+
 // ── Behavior: Skip day ──
 
 describe("skip day", () => {

--- a/src/lib/__tests__/mockSupabase.ts
+++ b/src/lib/__tests__/mockSupabase.ts
@@ -1,0 +1,239 @@
+/**
+ * In-memory mock of the Supabase client for testing.
+ *
+ * Instead of hitting a real database, this stores rows in plain arrays.
+ * When the module calls supabase.from("daily_entries").update(...),
+ * this mock intercepts the call and modifies the in-memory data.
+ *
+ * This lets us:
+ * - Set up specific test scenarios (e.g., "3 successes, remove the middle one")
+ * - Assert on the resulting state (e.g., "remaining are numbered 1 and 2")
+ * - Run tests instantly with no network or database
+ */
+
+type Row = Record<string, unknown>;
+
+interface TableStore {
+  rows: Row[];
+}
+
+/**
+ * Create a mock Supabase client backed by in-memory tables.
+ * Pass initial data like: { daily_entries: [{ id: "1", status: "success", ... }] }
+ */
+export function createMockSupabase(initialData: Record<string, Row[]> = {}) {
+  const tables: Record<string, TableStore> = {};
+
+  // Initialize tables with provided data
+  for (const [name, rows] of Object.entries(initialData)) {
+    tables[name] = { rows: rows.map((r) => ({ ...r })) };
+  }
+
+  function getTable(name: string): TableStore {
+    if (!tables[name]) tables[name] = { rows: [] };
+    return tables[name];
+  }
+
+  /** Helper to read the current state of a table (for assertions in tests) */
+  function getRows(tableName: string): Row[] {
+    return getTable(tableName).rows;
+  }
+
+  /**
+   * Build a chainable query builder that mimics Supabase's API.
+   * Supports: select, insert, update, upsert, delete, eq, neq, in, lte,
+   * order, limit, single, maybeSingle
+   */
+  function from(tableName: string) {
+    const table = getTable(tableName);
+    let filters: ((row: Row) => boolean)[] = [];
+    let orderBy: { column: string; ascending: boolean } | null = null;
+    let limitCount: number | null = null;
+
+    function applyFilters(rows: Row[]): Row[] {
+      let result = rows;
+      for (const f of filters) {
+        result = result.filter(f);
+      }
+      if (orderBy) {
+        const { column, ascending } = orderBy;
+        result = [...result].sort((a, b) => {
+          const va = String(a[column] ?? "");
+          const vb = String(b[column] ?? "");
+          return ascending ? va.localeCompare(vb) : vb.localeCompare(va);
+        });
+      }
+      if (limitCount !== null) {
+        result = result.slice(0, limitCount);
+      }
+      return result;
+    }
+
+    const builder = {
+      // Filters
+      eq(col: string, val: unknown) {
+        filters.push((row) => row[col] === val);
+        return builder;
+      },
+      neq(col: string, val: unknown) {
+        filters.push((row) => row[col] !== val);
+        return builder;
+      },
+      in(col: string, vals: unknown[]) {
+        filters.push((row) => vals.includes(row[col]));
+        return builder;
+      },
+      lte(col: string, val: unknown) {
+        filters.push((row) => String(row[col] ?? "") <= String(val));
+        return builder;
+      },
+
+      // Modifiers
+      order(col: string, opts?: { ascending?: boolean }) {
+        orderBy = { column: col, ascending: opts?.ascending ?? true };
+        return builder;
+      },
+      limit(n: number) {
+        limitCount = n;
+        return builder;
+      },
+
+      // Terminal operations
+      select(_cols?: string, _opts?: Record<string, unknown>) {
+        // Return a chainable query that resolves to filtered data.
+        // Key: eq/neq/order etc must return THIS object (not builder)
+        // so the then() method stays reachable in the chain.
+        const selectResult: Record<string, unknown> = {
+          eq(col: string, val: unknown) {
+            filters.push((row) => row[col] === val);
+            return selectResult;
+          },
+          neq(col: string, val: unknown) {
+            filters.push((row) => row[col] !== val);
+            return selectResult;
+          },
+          in(col: string, vals: unknown[]) {
+            filters.push((row) => vals.includes(row[col]));
+            return selectResult;
+          },
+          lte(col: string, val: unknown) {
+            filters.push((row) => String(row[col] ?? "") <= String(val));
+            return selectResult;
+          },
+          order(col: string, opts?: { ascending?: boolean }) {
+            orderBy = { column: col, ascending: opts?.ascending ?? true };
+            return selectResult;
+          },
+          limit(n: number) {
+            limitCount = n;
+            return selectResult;
+          },
+          single() {
+            const rows = applyFilters(table.rows);
+            return Promise.resolve({
+              data: rows[0] ?? null,
+              error: rows.length === 0 ? { code: "PGRST116", message: "not found" } : null,
+            });
+          },
+          maybeSingle() {
+            const rows = applyFilters(table.rows);
+            return Promise.resolve({ data: rows[0] ?? null, error: null });
+          },
+          then(resolve: (val: { data: Row[]; error: null; count?: number }) => void) {
+            const rows = applyFilters(table.rows);
+            const countOpt = _opts && "count" in _opts;
+            resolve({
+              data: rows,
+              error: null,
+              ...(countOpt ? { count: rows.length } : {}),
+            });
+          },
+        };
+        return selectResult;
+      },
+
+      insert(data: Row | Row[]) {
+        const rows = Array.isArray(data) ? data : [data];
+        for (const row of rows) {
+          const newRow = {
+            id: row.id ?? `mock-${Math.random().toString(36).slice(2, 9)}`,
+            ...row,
+            created_at: row.created_at ?? new Date().toISOString(),
+          };
+          table.rows.push(newRow);
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+
+      update(data: Partial<Row>) {
+        // Returns a builder that applies the update when filters resolve
+        const updateBuilder = {
+          eq(col: string, val: unknown) {
+            filters.push((row) => row[col] === val);
+            return updateBuilder;
+          },
+          neq(col: string, val: unknown) {
+            filters.push((row) => row[col] !== val);
+            return updateBuilder;
+          },
+          in(col: string, vals: unknown[]) {
+            filters.push((row) => vals.includes(row[col]));
+            return updateBuilder;
+          },
+          then(resolve: (val: { data: null; error: null }) => void) {
+            for (const row of table.rows) {
+              if (filters.every((f) => f(row))) {
+                Object.assign(row, data);
+              }
+            }
+            resolve({ data: null, error: null });
+          },
+        };
+        return updateBuilder;
+      },
+
+      upsert(data: Row, opts?: { onConflict?: string }) {
+        const conflictCols = opts?.onConflict?.split(",").map((c) => c.trim()) ?? ["id"];
+        const existing = table.rows.find((row) =>
+          conflictCols.every((col) => row[col] === data[col])
+        );
+        if (existing) {
+          Object.assign(existing, data);
+        } else {
+          const newRow = {
+            id: data.id ?? `mock-${Math.random().toString(36).slice(2, 9)}`,
+            ...data,
+            created_at: data.created_at ?? new Date().toISOString(),
+          };
+          table.rows.push(newRow);
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+
+      delete() {
+        const deleteBuilder = {
+          eq(col: string, val: unknown) {
+            filters.push((row) => row[col] === val);
+            return deleteBuilder;
+          },
+          then(resolve: (val: { data: null; error: null }) => void) {
+            table.rows = table.rows.filter((row) => !filters.every((f) => f(row)));
+            resolve({ data: null, error: null });
+          },
+        };
+        return deleteBuilder;
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    from,
+    getRows,
+  };
+}
+
+/** Type that makes the mock compatible with TypedSupabaseClient */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MockSupabase = ReturnType<typeof createMockSupabase>;

--- a/src/lib/dailyEntryLifecycle.ts
+++ b/src/lib/dailyEntryLifecycle.ts
@@ -10,7 +10,6 @@ import type { TypedSupabaseClient } from "@/lib/supabase/server";
 import type { EntryStatus } from "@/types/database";
 import {
   getDateInTimezone,
-  getDayOfWeekInTimezone,
   isAfterDeadline,
 } from "@/lib/deadlineUtils";
 
@@ -53,8 +52,14 @@ export async function recalculateSuccessNumbers(
 // ── Page Load Bootstrapping ────────────────────────────────────────
 
 /**
- * Ensure today's daily entry exists and transition stale pending entries.
- * Called on dashboard page load. Respects admin edits via updated_by.
+ * Ensure every past active-weekday from start_date through today has a daily
+ * entry, and transition stale pending entries to "miss". Called on dashboard
+ * and admin page loads. Respects admin edits via updated_by — existing entries
+ * are never overwritten.
+ *
+ * Why back-fill the past: if the app isn't opened on a given day, we still want
+ * the calendar and Edit Entries screen to record it as a miss. Otherwise the
+ * day silently disappears from history.
  */
 export async function bootstrapDailyEntries(
   supabase: TypedSupabaseClient,
@@ -72,26 +77,51 @@ export async function bootstrapDailyEntries(
 
   const tz = goal.timezone;
   const today = getDateInTimezone(now, tz);
-  const dayOfWeek = getDayOfWeekInTimezone(now, tz);
   const activeDays = (goal.active_days as number[]) ?? [];
+  const pastDeadline = isAfterDeadline(now, goal.deadline_time, tz);
 
-  // Create today's entry if it's an active day and doesn't exist yet
-  if (activeDays.includes(dayOfWeek) && today >= goal.start_date) {
-    const { data: todayEntry } = await supabase
+  // Build the list of active-weekday dates from start_date through today
+  const expectedDates: string[] = [];
+  if (today >= goal.start_date) {
+    const [sy, sm, sd] = goal.start_date.split("-").map(Number);
+    const [ty, tm, td] = today.split("-").map(Number);
+    const cursor = new Date(sy, sm - 1, sd);
+    const end = new Date(ty, tm - 1, td);
+    while (cursor <= end) {
+      if (activeDays.includes(cursor.getDay())) {
+        const yyyy = cursor.getFullYear();
+        const mm = String(cursor.getMonth() + 1).padStart(2, "0");
+        const dd = String(cursor.getDate()).padStart(2, "0");
+        expectedDates.push(`${yyyy}-${mm}-${dd}`);
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  if (expectedDates.length > 0) {
+    const { data: existing } = await supabase
       .from("daily_entries")
-      .select("id")
+      .select("date")
       .eq("goal_id", goalId)
-      .eq("date", today)
-      .maybeSingle();
+      .in("date", expectedDates);
 
-    if (!todayEntry) {
-      const pastDeadline = isAfterDeadline(now, goal.deadline_time, tz);
-      await supabase.from("daily_entries").insert({
+    const existingDates = new Set(
+      (existing ?? []).map((e: { date: string }) => e.date)
+    );
+
+    const toInsert = expectedDates
+      .filter((date) => !existingDates.has(date))
+      .map((date) => ({
         goal_id: goalId,
-        date: today,
-        status: (pastDeadline ? "miss" : "pending") as "miss" | "pending",
+        date,
+        status: (date < today || pastDeadline ? "miss" : "pending") as
+          | "miss"
+          | "pending",
         updated_by: "system",
-      });
+      }));
+
+    if (toInsert.length > 0) {
+      await supabase.from("daily_entries").insert(toInsert);
     }
   }
 
@@ -109,7 +139,7 @@ export async function bootstrapDailyEntries(
       const missedIds = pendingEntries
         .filter((entry: { id: string; date: string }) => {
           if (entry.date < today) return true;
-          return entry.date === today && isAfterDeadline(now, goal.deadline_time, tz);
+          return entry.date === today && pastDeadline;
         })
         .map((entry: { id: string; date: string }) => entry.id);
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- **Back-fill missed days** — `bootstrapDailyEntries` now walks every date from `start_date` through today and, for each date whose day-of-week is in the goal's configured `active_days`, inserts a `miss` if no entry exists. Goals configured for weekdays only, weekends only, or any custom subset are respected — only the days that goal is *supposed* to track get back-filled. Existing entries (admin edits, skips, successes) are never overwritten. Also runs from the admin entries page so the back-fill doesn't depend on the dashboard being opened first.
- **Scroll the calendar inside its card** — when a goal ran long, the whole page scrolled and pushed the jar and check-in buttons off-screen. The calendar now scrolls internally; jar/buttons stay visible at all times.
- **Lifecycle test suite** — vitest with an in-memory mock Supabase. 12 tests covering success-number sequencing, admin-edit preservation, status-transition side effects, team vs individual completion, skip-day, and the new back-fill behavior (including a test that verifies inactive days are skipped).

## Test plan
- [ ] `npm test` passes (12 tests)
- [ ] On a goal with many weeks of history, the kid dashboard keeps the jar and check-in buttons on-screen while scrolling the calendar
- [ ] Open a goal whose dashboard hasn't been viewed for several days — past *active* days (per the goal's config) now show as X on the calendar and as miss rows in Edit Entries; *non-active* days remain blank
- [ ] Skipped days remain greyed out (not converted to miss)
- [ ] Admin-edited successes/pending entries are preserved across page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)